### PR TITLE
Add PDA wallet support for ATA derivation

### DIFF
--- a/common-ts/src/common-ui-utils/commonUiUtils.ts
+++ b/common-ts/src/common-ui-utils/commonUiUtils.ts
@@ -581,7 +581,8 @@ const getTokenAddress = (
 ): Promise<PublicKey> => {
 	return getAssociatedTokenAddress(
 		new PublicKey(mintAddress),
-		new PublicKey(userPubKey)
+		new PublicKey(userPubKey),
+		true
 	);
 };
 
@@ -612,7 +613,8 @@ const getTokenAccount = async (
 
 	const associatedAddress = await getAssociatedTokenAddress(
 		new PublicKey(mintAddress),
-		new PublicKey(userPubKey)
+		new PublicKey(userPubKey),
+		true
 	);
 
 	const targetAccount =

--- a/common-ts/src/utils/token.ts
+++ b/common-ts/src/utils/token.ts
@@ -10,7 +10,8 @@ export const getTokenAddress = (
 ): Promise<PublicKey> => {
 	return getAssociatedTokenAddress(
 		new PublicKey(mintAddress),
-		new PublicKey(userPubKey)
+		new PublicKey(userPubKey),
+		true
 	);
 };
 
@@ -31,7 +32,8 @@ export const getTokenAccount = async (
 
 	const associatedAddress = await getAssociatedTokenAddress(
 		new PublicKey(mintAddress),
-		new PublicKey(userPubKey)
+		new PublicKey(userPubKey),
+		true
 	);
 
 	const targetAccount =
@@ -51,7 +53,11 @@ export const createTokenAccountIx = async (
 		payer = owner;
 	}
 
-	const associatedAddress = await getAssociatedTokenAddress(mintAddress, owner);
+	const associatedAddress = await getAssociatedTokenAddress(
+		mintAddress,
+		owner,
+		true
+	);
 
 	const createAtaIx = await createAssociatedTokenAccountInstruction(
 		payer,


### PR DESCRIPTION
Setting allowOwnerOffCurve = true so that info from ATA's where a PDA is the authority can be fetched.