### PR TITLE
Fixed Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ### quick start
 ```
 git submodule init
-git submoudle update
+git submodule update
 
 yarn
 


### PR DESCRIPTION
git submoudle update

becomes

git submodule update

```
git: 'submoudle' is not a git command. See 'git --help'.

The most similar command is
	submodule
```