### PR TITLE
Allow calc liq price for `stopMarket`, `stopLimit`, `oracleLimit`

### DIFF
--- a/common-ts/src/common-ui-utils/trading.ts
+++ b/common-ts/src/common-ui-utils/trading.ts
@@ -166,7 +166,14 @@ const calculateLiquidationPriceAfterPerpTrade = ({
 	isEnteringHighLeverageMode?: boolean;
 	capLiqPrice?: boolean;
 }) => {
-	const ALLOWED_ORDER_TYPES: UIOrderType[] = ['limit', 'market', 'oracle'];
+	const ALLOWED_ORDER_TYPES: UIOrderType[] = [
+		'limit',
+		'market',
+		'oracle',
+		'stopMarket',
+		'stopLimit',
+		'oracleLimit',
+	];
 
 	if (!ALLOWED_ORDER_TYPES.includes(orderType)) {
 		console.error(
@@ -184,7 +191,14 @@ const calculateLiquidationPriceAfterPerpTrade = ({
 	}
 
 	const signedBaseSize = isLong ? tradeBaseSize : tradeBaseSize.neg();
-	const priceToUse = orderType === 'limit' ? limitPrice : estEntryPrice;
+	const priceToUse = [
+		'limit',
+		'stopMarket',
+		'stopLimit',
+		'oracleLimit',
+	].includes(orderType)
+		? limitPrice
+		: estEntryPrice;
 
 	const liqPriceBn = userClient.liquidationPrice(
 		perpMarketIndex,


### PR DESCRIPTION
We want to show the estimated liquidation price in the trade details for stop market, stop limit, and oracle limit orders as well. The corresponding `ui` change will be made in [this PR](https://github.com/drift-labs/protocol-v2-mono/pull/3740).