### PR TITLE
Fix `useSyncLocalStorage` initial value loss

### DIFF
--- a/react/src/hooks/useSyncLocalStorage.ts
+++ b/react/src/hooks/useSyncLocalStorage.ts
@@ -27,9 +27,17 @@ export function useSyncLocalStorage<T>(
 	const [storedValue, setStoredValue] = useState<T>(() => {
 		try {
 			const storage = safeLocalStorage();
-			if (!storage) return initialValue;
+			if (!storage) {
+				return initialValue;
+			}
+
 			const item = storage.getItem(key);
-			return item ? (JSON.parse(item) as T) : initialValue;
+			if (item != null) {
+				return JSON.parse(item) as T;
+			}
+
+			localStorage.setItem(key, JSON.stringify(initialValue));
+			return initialValue;
 		} catch (error) {
 			console.log(error);
 			return initialValue;
@@ -63,9 +71,15 @@ export function useSyncLocalStorage<T>(
 				if (!storage) return;
 
 				const newValue = JSON.parse(storage.getItem(key) as string) as T;
-				if (newValue !== storedValue) {
-					setStoredValue(newValue);
+
+				// If the item has been removed, reset to the initial value.
+				// Note, this will also add the item back to `localStorage` itself.
+				if (newValue == null) {
+					setValue(initialValue);
+					return;
 				}
+
+				setStoredValue(newValue);
 			} catch (error) {
 				console.log(error);
 			}


### PR DESCRIPTION
Currently `useSyncLocalStorage` does not actually set the initial value in local storage, even though the comment [here](https://github.com/drift-labs/drift-common/blob/master/react/src/hooks/useSyncLocalStorage.ts#L12) implies it does. 

Relatedly, since the item never actually exists in storage, if the user updates some other item, and the effect [here](https://github.com/drift-labs/drift-common/blob/master/react/src/hooks/useSyncLocalStorage.ts#L59) runs, the hook will start returning `null` for the value instead of the initial value. This can also of course happen if the user clears their storage / deletes said item, and subsequently updates another item.

I think expected behavior would be a) for the initial value to actually get saved in storage, and b) for the hook to revert back to returning the initial value when the item's been deleted. Open to other approaches though!

Realized this while working on some orderbook changes. When using this hook to manage the display preference (i.e. vertical / horizontal), the [app will break](https://github.com/drift-labs/protocol-v2-mono/blob/master/ui/src/components/Orderbook/OrderbookUtils.ts#L248) if the user hasn't explicitly updated this preference and performs some action to trigger a storage update (e.g. change order type).