### PR TITLE
Fix multiple-page candles fetching

### DIFF
--- a/common-ts/src/clients/candleClient.ts
+++ b/common-ts/src/clients/candleClient.ts
@@ -175,6 +175,9 @@ class CandleFetcher {
 		this.config = config;
 	}
 
+	/**
+	 * Candles are fetched in ascending order of time (index 0 -> oldest to index n -> newest)
+	 */
 	private fetchCandlesFromApi = async (
 		fetchUrl: string
 	): Promise<JsonCandle[]> => {
@@ -424,7 +427,8 @@ class CandleFetcher {
 				return candle.ts < lastCandle.ts;
 			});
 
-			nextStartTs = lastCandle.ts; // If we are doing another loop, then the trimmed candles have all the candles except for ones with the last candle's timestamp. For the next loop we want to fetch from that timestamp;
+			const oldestCandle = fetchedCandles[0]; // first candle is the oldest
+			nextStartTs = oldestCandle.ts; // If we are doing another loop, then the trimmed candles have all the candles except for ones with the last candle's timestamp. For the next loop we want to fetch from that timestamp;
 		}
 
 		return {


### PR DESCRIPTION
Fetching candles with an expectation of more than 1000 candles, causes TradingView to break, because second page of candles are fetched with the incorrect start time. It uses the newest candle instead of the oldest candle as the second page's start time

https://github.com/user-attachments/assets/d475b7c9-43ff-43d3-aad5-44c8f2e926dc

