### PR TITLE
`useSyncLocalStorage`: Don't store nullish vals & allow no `initialValue`

### DIFF
--- a/react/src/hooks/useSyncLocalStorage.ts
+++ b/react/src/hooks/useSyncLocalStorage.ts
@@ -77,14 +77,6 @@ export function useSyncLocalStorage<T>(
 		[storedValue, storage]
 	);
 
-	const resetValue = useCallback(() => {
-		if (initialValue != null) {
-			storage?.setItem(key, getValueToStore(initialValue));
-		}
-
-		setStoredValue(initialValue);
-	}, [initialValue, key, storage]);
-
 	useEffect(() => {
 		const handleStorageChange = () => {
 			try {
@@ -94,10 +86,8 @@ export function useSyncLocalStorage<T>(
 
 				const newValue = storage.getItem(key);
 
-				// If the item has been removed, reset to the initial value. Note, if the
-				// initial value isn't nullish, the item will be added back to `localStorage`.
 				if (newValue == null) {
-					resetValue();
+					setStoredValue(newValue as T | undefined);
 					return;
 				}
 


### PR DESCRIPTION
Recently we updated the `useSyncLocalStorage` hook to save the initial value to `localStorage` in the case it didn’t already exist. However, we don’t check if the value is `undefined` before storing, so an error can be thrown after we retrieve it and run `JSON.parse(undefined)`. The page won’t break, but an error will be logged to the console. A simple example of this kind of case can be found [here](https://github.com/drift-labs/protocol-v2-mono/blob/master/ui/src/hooks/useHasAcknowledgedTerms.tsx#L17). Open any preview branch for the first time and you'll likely see a related error in the console

While looking into the above issue I also realized the `initialValue` argument is required, and as such we pass in `undefined` and `null` in places we probably shouldn’t have to (e.g. the above case). I think it makes more sense for it to be nullable, and for the types to reflect that. Basically, it should act like `useState`, except for one case. So I’ve updated the types as well to have the following behavior:

```tsx
type STATE = 'off' | 'on'

// Generic and no initial: `state` has type `STATE | undefined`
// This is like `useState<STATE>()`
const [state] = useSyncLocalStorage<STATE>('state');

// Generic and initial: `state` has type `STATE`
// This is like `useState<STATE>('off')
const [state] = useSyncLocalStorage<STATE>('state', 'off');

// Initial and no generic: `state` has type of initial (string in this case)
// This is like `useState('off')
const [state] = useSyncLocalStorage('state', 'off');

// No initial and no generic: `state` has type `unknown` becase we really have
// no idea what will be returned. We should pretty rarely do this.
const [state] = useSyncLocalStorage('state')

```

Does this make sense? Anything I’ve overlooked?

Update: this PR also add some logic that avoids running `JSON.stringify` on strings and silences errors when `JSON.parse`ing (so we don't log errors when parsing strings).

**Testing**

Would be good to check the several places we currently use this hook and ensure it still behaves as expected.