### PR TITLE
chore(ci): pin github actions to commit shas

### DIFF
--- a/.github/workflows/common-ts.yml
+++ b/.github/workflows/common-ts.yml
@@ -19,16 +19,16 @@ jobs:
       run:
         working-directory: ./common-ts
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24.x.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
         with:
           bun-version: 1.2.15
 
@@ -46,8 +46,8 @@ jobs:
     outputs:
       common-ts: ${{ steps.filter.outputs.common-ts }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
         id: filter
         with:
           filters: |
@@ -64,18 +64,18 @@ jobs:
     outputs:
       version: ${{ steps.git-commit.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.GH_PAT }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24.x.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
         with:
           bun-version: 1.2.15
 
@@ -113,7 +113,7 @@ jobs:
 
       - name: Notify Slack on failure
         if: failure()
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
@@ -129,7 +129,7 @@ jobs:
         repo: ["dlob-server", "internal-keeper-bot", "history-server"]
     steps:
       - name: Checkout code with new updated version
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Emit dispatch event
         run: |
           curl -X POST \

--- a/.github/workflows/posthog-types.yml
+++ b/.github/workflows/posthog-types.yml
@@ -19,16 +19,16 @@ jobs:
       run:
         working-directory: ./posthog-types
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24.x.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
         with:
           bun-version: 1.2.15
 
@@ -43,8 +43,8 @@ jobs:
     outputs:
       posthog-types: ${{ steps.filter.outputs.posthog-types }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
         id: filter
         with:
           filters: |
@@ -59,18 +59,18 @@ jobs:
       run:
         working-directory: ./posthog-types
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.GH_PAT }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24.x.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
         with:
           bun-version: 1.2.15
 
@@ -108,7 +108,7 @@ jobs:
 
       - name: Notify Slack on failure
         if: failure()
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -19,16 +19,16 @@ jobs:
       run:
         working-directory: ./react
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24.x.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
         with:
           bun-version: 1.3.9
 


### PR DESCRIPTION
## Summary
- Pin every third-party action in `common-ts.yml`, `posthog-types.yml`, and `react.yml` to a full-length commit SHA, with the original tag preserved as a trailing comment for readability.
- Affected actions: `actions/checkout@v4`, `actions/setup-node@v4`, `oven-sh/setup-bun@v1`, `dorny/paths-filter@v2`, `slackapi/slack-github-action@v1.24.0`.
- Mitigates supply-chain risk from mutable tags being repointed to malicious commits (per GitHub's hardening guidance and recent `tj-actions/changed-files` style incidents).

## Test plan
- [ ] CI runs (`react`, `common-ts`, `posthog-types` workflows) succeed on this PR.
- [ ] On merge, the `release` and `emit-dispatch-events` jobs in `common-ts.yml` continue to behave normally on the next master push that touches `common-ts/`.