### PR TITLE
ci(common-ts): use npm trusted publishing for release

### DIFF
--- a/.github/workflows/common-ts-release.yml
+++ b/.github/workflows/common-ts-release.yml
@@ -1,4 +1,4 @@
-name: common-ts
+name: common-ts-release
 
 on:
   push:
@@ -41,6 +41,15 @@ jobs:
       - name: Run tests
         run: bun run test:ci
 
+      - name: Upload build artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: common-ts-lib
+          path: common-ts/lib
+          retention-days: 1
+          if-no-files-found: error
+
   check-for-common-ts-changes:
     runs-on: ubicloud
     outputs:
@@ -54,10 +63,13 @@ jobs:
             common-ts:
               - 'common-ts/**'
 
-  release:
-    runs-on: ubicloud
+  publish:
+    runs-on: ubuntu-latest
     needs: [tests, check-for-common-ts-changes]
     if: ${{ github.ref == 'refs/heads/master' && needs.check-for-common-ts-changes.outputs.common-ts == 'true' }}
+    permissions:
+      contents: write # push the version bump commit
+      id-token: write # mint OIDC token for npm Trusted Publishing
     defaults:
       run:
         working-directory: ./common-ts
@@ -74,16 +86,14 @@ jobs:
           node-version: '24.x.x'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Setup bun
-        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
+      - name: Download latest npm # ensures that npm version supports trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Download build artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          bun-version: 1.2.15
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Build
-        run: bun run build
+          name: common-ts-lib
+          path: common-ts/lib
 
       - name: Update package version
         run: |
@@ -91,7 +101,7 @@ jobs:
           npm version patch
           echo "PACKAGE_VERSION=$(node -e "console.log(require('./package.json').version);")" >> $GITHUB_ENV
 
-      - name: Git commit
+      - name: Git commit version bump
         id: git-commit
         run: |
           git config user.name "GitHub Actions"
@@ -107,9 +117,7 @@ jobs:
           echo "version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
 
       - name: Publish to npm
-        run: npm publish --access=public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access=public --provenance
 
       - name: Notify Slack on failure
         if: failure()
@@ -122,11 +130,11 @@ jobs:
 
   emit-dispatch-events:
     runs-on: ubicloud
-    needs: [release, check-for-common-ts-changes]
+    needs: [publish, check-for-common-ts-changes]
     if: ${{ github.ref == 'refs/heads/master' && needs.check-for-common-ts-changes.outputs.common-ts == 'true' }}
     strategy:
       matrix:
-        repo: ["dlob-server", "internal-keeper-bot", "history-server"]
+        repo: ['dlob-server', 'internal-keeper-bot', 'history-server']
     steps:
       - name: Checkout code with new updated version
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -142,5 +150,5 @@ jobs:
             }}"
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
-          VERSION: ${{ needs.release.outputs.version }}
+          VERSION: ${{ needs.publish.outputs.version }}
         working-directory: ./common-ts


### PR DESCRIPTION
## Summary
- Switch the `common-ts` release workflow from token-based `npm publish` (`NPM_TOKEN`) to npm Trusted Publishing via OIDC (`id-token: write` + `--provenance`).
- Rename the workflow (`common-ts.yml` → `common-ts-release.yml`, `name: common-ts-release`) and rename the `release` job to `publish`.
- Split build and publish: the `tests` job now uploads a `common-ts-lib` artifact on master pushes; the `publish` job runs on `ubuntu-latest`, downloads the artifact, and upgrades to the latest npm (required for trusted publishing) instead of re-running bun build.
- Update downstream `bump-dependencies` matrix to depend on the renamed `publish` job and reference `needs.publish.outputs.version`.

## Test plan
- [ ] Merge to master with a `common-ts` change and confirm the `publish` job mints an OIDC token, publishes with provenance, and the version-bump commit is pushed.
- [ ] Confirm `bump-dependencies` matrix still kicks off against `dlob-server`, `internal-keeper-bot`, and `history-server` with the published version.
- [ ] Confirm trusted publishing is configured on the npm package side (`@drift-labs/common-ts`) for this repo/workflow before merging.