### PR TITLE
docs: add common-ts CLAUDE.md simplification standard

### DIFF
--- a/common-ts/CLAUDE.md
+++ b/common-ts/CLAUDE.md
@@ -1,0 +1,51 @@
+# common-ts
+
+Shared TypeScript library (`@velocity-exchange/common`) of utilities, clients, and
+drift/Velocity domain logic. Published to npm and consumed by other apps, so the
+public API surface is a contract.
+
+## Build & verify
+
+```bash
+bun run build          # tsc -> lib/, must stay clean
+bun run test           # mocha, non-drift suites
+bun run test:drift     # mocha, drift/Velocity suites
+bun run circular-deps  # madge, must report no cycles
+```
+
+Run build + the relevant test suite + circular-deps before considering any change done.
+
+Baseline (master, as of 2026-06-18): build clean, non-drift tests 106 passing,
+circular-deps clean. `test:drift` is **already failing** on master from a pre-existing
+type error in `tests/drift/.../accountManagement.test.ts` (a `PublicKey` passed where a
+`User` is expected) — not caused by simplification work; don't attribute it to a change.
+
+## Public API is a contract
+
+Every subpath in `package.json` `exports` (`.`, `./clients`, `./utils/math`,
+`./utils/strings`, `./utils/enum`, `./utils/validation`, `./utils/token`,
+`./utils/trading`, `./utils/markets`, `./utils/orders`, `./utils/positions`,
+`./utils/accounts`, `./utils/core`) is imported by downstream apps. Do not rename or
+remove exported symbols reachable from these without an explicit migration. Symbols that
+are internal-only (verify with `rg` across `src`) are free to refactor or delete.
+
+## What "simple" means here
+
+- **Comments:** default to none. Keep only comments that explain a non-obvious *why* —
+  a hidden constraint, a workaround for a known bug, surprising behavior. Delete comments
+  that restate the code, reference a past task/PR/ticket, or mark `// removed` / `// deprecated`.
+- **No compat cruft:** no backwards-compat shims, no `_unused`-renamed vars kept "for compat",
+  no re-exports with no consumer, no dead feature-flag branches.
+- **No defensive code at internal boundaries:** validate at true system boundaries only
+  (network responses, user input, external SDK contracts that throw). Don't add null checks
+  or try/catch around trusted internal calls the types already guarantee.
+- **Prefer inline over premature abstraction:** three similar inline lines beat a
+  single-call-site helper. Don't add generic params or wrappers for a hypothetical second caller.
+- Real deduplication of large near-identical blocks is welcome; collapsing three short
+  similar lines into a clever abstraction is not.
+
+## Type safety
+
+`strictNullChecks` is currently **off** in `tsconfig.json` (there's a standing TODO to
+enable it). Flag null-safety bugs you find, but enabling the flag is a separate, larger
+project — don't turn it on as part of a simplification pass.


### PR DESCRIPTION
Adds a `CLAUDE.md` to `common-ts` codifying the simplification standard ahead of a module-by-module simplify+improve effort.

## What it defines
- **Build/verify gates** — `build`, `test`, `test:drift`, `circular-deps`, with the current baseline recorded.
- **Public API is a contract** — lists all 13 `exports` subpaths; exported symbols can't be renamed/removed without migration, internal-only symbols are free to refactor.
- **What "simple" means here** — no comments by default (keep only non-obvious *why*), no compat cruft, no defensive code at internal boundaries, inline over premature abstraction.
- **Type safety** — `strictNullChecks` is off; enabling it is a separate larger project, not part of simplification passes.

## Baseline note
`test:drift` is already failing on `master` from a pre-existing type error in `tests/drift/.../accountManagement.test.ts` (a `PublicKey` passed where a `User` is expected) — documented so it isn't misattributed to later changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)