### PR TITLE
refactor(common-ts): simplify domain utils cluster + fix latent bugs

### DIFF
--- a/common-ts/src/utils/candles/Candle.ts
+++ b/common-ts/src/utils/candles/Candle.ts
@@ -91,7 +91,6 @@ export class Candle {
 
 		if (props.fillHigh.lt(props.fillClose)) {
 			logBadCandleProp();
-			logBadCandleProp();
 			safeProps.fillHigh = safeProps.fillClose;
 		}
 
@@ -242,43 +241,37 @@ export class Candle {
 		const handleBadCandle =
 			props.handleBadCandle ?? FLAGS.DEFAULT_HANDLE_BAD_CANDLES;
 
-		// eslint-disable-next-line no-useless-catch
-		try {
-			if (handleBadCandle) {
-				const safeProps = Candle.getSafeProps(props);
+		if (handleBadCandle) {
+			const safeProps = Candle.getSafeProps(props);
 
-				this.start = safeProps.start;
-				this.fillOpen = safeProps.fillOpen;
-				this.fillHigh = safeProps.fillHigh;
-				this.fillClose = safeProps.fillClose;
-				this.fillLow = safeProps.fillLow;
-				this.oracleOpen = safeProps.oracleOpen;
-				this.oracleHigh = safeProps.oracleHigh;
-				this.oracleClose = safeProps.oracleClose;
-				this.oracleLow = safeProps.oracleLow;
-				this.quoteVolume = safeProps.quoteVolume;
-				this.baseVolume = safeProps.baseVolume;
-				this.resolution = safeProps.resolution;
+			this.start = safeProps.start;
+			this.fillOpen = safeProps.fillOpen;
+			this.fillHigh = safeProps.fillHigh;
+			this.fillClose = safeProps.fillClose;
+			this.fillLow = safeProps.fillLow;
+			this.oracleOpen = safeProps.oracleOpen;
+			this.oracleHigh = safeProps.oracleHigh;
+			this.oracleClose = safeProps.oracleClose;
+			this.oracleLow = safeProps.oracleLow;
+			this.quoteVolume = safeProps.quoteVolume;
+			this.baseVolume = safeProps.baseVolume;
+			this.resolution = safeProps.resolution;
 
-				return;
-			} else {
-				Candle.sanityCheckProps(props);
-				this.start = props.start;
-				this.fillOpen = props.fillOpen;
-				this.fillHigh = props.fillHigh;
-				this.fillClose = props.fillClose;
-				this.fillLow = props.fillLow;
-				this.oracleOpen = props.oracleOpen;
-				this.oracleHigh = props.oracleHigh;
-				this.oracleClose = props.oracleClose;
-				this.oracleLow = props.oracleLow;
-				this.quoteVolume = props.quoteVolume;
-				this.baseVolume = props.baseVolume;
-				this.resolution = props.resolution;
-			}
-		} catch (e) {
-			// Just doing this syntax for an easy breakpoint to catch bad props
-			throw e;
+			return;
+		} else {
+			Candle.sanityCheckProps(props);
+			this.start = props.start;
+			this.fillOpen = props.fillOpen;
+			this.fillHigh = props.fillHigh;
+			this.fillClose = props.fillClose;
+			this.fillLow = props.fillLow;
+			this.oracleOpen = props.oracleOpen;
+			this.oracleHigh = props.oracleHigh;
+			this.oracleClose = props.oracleClose;
+			this.oracleLow = props.oracleLow;
+			this.quoteVolume = props.quoteVolume;
+			this.baseVolume = props.baseVolume;
+			this.resolution = props.resolution;
 		}
 	}
 

--- a/common-ts/src/utils/markets/balances.ts
+++ b/common-ts/src/utils/markets/balances.ts
@@ -15,7 +15,7 @@ export const getTotalBorrowsForMarket = (
 
 	const totalBorrowsTokenAmount = getTokenAmount(
 		marketAccount.borrowBalance,
-		velocityClient.getSpotMarketAccount(marketAccount.marketIndex),
+		marketAccount,
 		SpotBalanceType.BORROW
 	);
 

--- a/common-ts/src/utils/orderbook/index.ts
+++ b/common-ts/src/utils/orderbook/index.ts
@@ -312,8 +312,7 @@ export const getUserLiquidityForPrice = ({
 	let isCurrentUserLiquidity = false;
 	let currentUserLiquiditySize = 0;
 
-	const priceToUse = price;
-	const priceBucket = getBucketFloorForPrice(priceToUse, groupingSizeValue);
+	const priceBucket = getBucketFloorForPrice(price, groupingSizeValue);
 
 	const lookupBucket =
 		side === 'bid' ? userBidPriceBucketLookup : userAskPriceBucketLookup;

--- a/common-ts/src/utils/orders/filters.ts
+++ b/common-ts/src/utils/orders/filters.ts
@@ -16,22 +16,18 @@ import { matchEnum, ENUM_UTILS } from '../enum';
 export const orderActionRecordIsTrade = (orderRecord: OrderActionRecord) =>
 	orderRecord.baseAssetAmountFilled.gt(ZERO) &&
 	// @ts-ignore
-	matchEnum(orderRecord.action, OrderAction.FILL) &&
-	true;
+	matchEnum(orderRecord.action, OrderAction.FILL);
 
 export const uiOrderActionRecordIsTrade = (
 	orderRecord: UISerializableOrderActionRecord
 ) =>
 	orderRecord.baseAssetAmountFilled.gtZero() &&
-	matchEnum(orderRecord.action, OrderAction.FILL) &&
-	true;
+	matchEnum(orderRecord.action, OrderAction.FILL);
 
-// Trade records are order records which have been filled
 export const filterTradeRecordsFromOrderActionRecords = (
 	orderRecords: OrderActionRecord[]
 ): OrderActionRecord[] => orderRecords.filter(orderActionRecordIsTrade);
 
-// Trade records are order records which have been filled
 export const filterTradeRecordsFromUIOrderRecords = (
 	orderRecords: UISerializableOrderActionRecord[]
 ): UISerializableOrderActionRecord[] =>

--- a/common-ts/src/utils/orders/sort.ts
+++ b/common-ts/src/utils/orders/sort.ts
@@ -111,7 +111,7 @@ export const sortUIMatchedOrderRecordAndAction = (
 	records: UIMatchedOrderRecordAndAction[],
 	direction: 'asc' | 'desc' = 'desc'
 ) => {
-	const ascSortedRecords = records.sort((a, b) =>
+	const ascSortedRecords = [...records].sort((a, b) =>
 		getSortScoreForOrderActionRecords(a.actionRecord, b.actionRecord)
 	);
 
@@ -122,7 +122,7 @@ export const sortUIOrderActionRecords = (
 	records: PartialUISerializableOrderActionRecord[],
 	direction: 'asc' | 'desc' = 'desc'
 ) => {
-	const ascSortedRecords = records.sort(getSortScoreForOrderActionRecords);
+	const ascSortedRecords = [...records].sort(getSortScoreForOrderActionRecords);
 
 	return direction === 'desc' ? ascSortedRecords.reverse() : ascSortedRecords;
 };
@@ -131,7 +131,7 @@ export const sortUIOrderRecords = <T extends { slot: number }>(
 	records: T[],
 	direction: 'asc' | 'desc' = 'desc'
 ) => {
-	const ascSortedRecords = records.sort(getSortScoreForOrderRecords);
+	const ascSortedRecords = [...records].sort(getSortScoreForOrderRecords);
 
 	return direction === 'desc' ? ascSortedRecords.reverse() : ascSortedRecords;
 };
@@ -140,7 +140,7 @@ export const sortOrderRecords = (
 	records: Event<OrderRecord>[],
 	direction: 'asc' | 'desc' = 'desc'
 ) => {
-	const ascSortedRecords = records.sort(getSortScoreForOrderRecords);
+	const ascSortedRecords = [...records].sort(getSortScoreForOrderRecords);
 
 	return direction === 'desc' ? ascSortedRecords.reverse() : ascSortedRecords;
 };

--- a/common-ts/src/utils/positions/open.ts
+++ b/common-ts/src/utils/positions/open.ts
@@ -4,7 +4,6 @@ import {
 	BigNum,
 	VelocityClient,
 	MarketStatus,
-	ONE,
 	PRICE_PRECISION,
 	PRICE_PRECISION_EXP,
 	PerpMarketConfig,
@@ -79,12 +78,10 @@ const getOpenPositionData = (
 
 				if (isResolved) {
 					const resolvedToNo = perpMarket.expiryPrice.lte(
-						ZERO.add(perpMarket.amm.orderTickSize)
+						perpMarket.amm.orderTickSize
 					);
 
-					const price = resolvedToNo
-						? ZERO.mul(PRICE_PRECISION)
-						: ONE.mul(PRICE_PRECISION);
+					const price = resolvedToNo ? ZERO : PRICE_PRECISION;
 
 					estExitPrice = price;
 					markPrice = price;

--- a/common-ts/src/utils/priority-fees/PriorityFeeStrategies.ts
+++ b/common-ts/src/utils/priority-fees/PriorityFeeStrategies.ts
@@ -54,9 +54,11 @@ const movingWindowTargetPercentileStrategy = (
 				  2
 				: allRecentSamplesAscendingSorted[targetPercentileIndex];
 
-			LAST_SEEN_SLOT_IN_SAMPLES = Math.max(
-				...filteredSamples.map((sample) => sample.slot)
-			);
+			if (filteredSamples.length > 0) {
+				LAST_SEEN_SLOT_IN_SAMPLES = Math.max(
+					...filteredSamples.map((sample) => sample.slot)
+				);
+			}
 
 			return pFee;
 		},

--- a/common-ts/src/utils/trading/auction.ts
+++ b/common-ts/src/utils/trading/auction.ts
@@ -147,9 +147,7 @@ const getMarketAuctionParams = ({
 };
 
 /**
- * Helper function which derived market order params from the CORE data that is used to create them.
- * @param param0
- * @returns
+ * Helper function which derives market order params from the CORE data that is used to create them.
  */
 const deriveMarketOrderParams = ({
 	marketType,
@@ -366,7 +364,6 @@ const getPriceObject = ({
 	);
 
 	if (nonZeroOptions.length === 0) {
-		// console.error('Unable to create valid auction params');
 		return {
 			oracle: ZERO,
 			bestOffer: ZERO,

--- a/common-ts/src/utils/trading/leverage.ts
+++ b/common-ts/src/utils/trading/leverage.ts
@@ -55,27 +55,22 @@ const validateLeverageChange = ({
 	newLeverage: number;
 }): boolean => {
 	try {
-		// Convert leverage to margin ratio
 		const newMarginRatio = convertLeverageToMarginRatio(newLeverage);
 		if (!newMarginRatio) return true;
 
-		// Get the perp position from the user
 		const perpPosition = user.getPerpPosition(marketIndex);
 		if (!perpPosition) return true;
 
-		// Get current position weighted value
 		const currentPositionWeightedValue = user.getPerpPositionHealth({
 			marginCategory: 'Initial',
 			perpPosition,
 		}).weightedValue;
 
-		// Create a modified version of the position with new maxMarginRatio
 		const modifiedPosition = {
 			...perpPosition,
 			maxMarginRatio: newMarginRatio,
 		};
 
-		// Calculate new weighted value with the modified position
 		const newPositionWeightedValue = user.getPerpPositionHealth({
 			marginCategory: 'Initial',
 			perpPosition: modifiedPosition,
@@ -87,7 +82,6 @@ const validateLeverageChange = ({
 
 		const freeCollateral = user.getFreeCollateral();
 
-		// Check if weighted value delta exceeds free collateral
 		return perpPositionWeightedValueDelta.lte(freeCollateral);
 	} catch (error) {
 		console.warn('Error validating leverage change:', error);

--- a/common-ts/src/utils/trading/pnl.ts
+++ b/common-ts/src/utils/trading/pnl.ts
@@ -102,9 +102,7 @@ const calculatePotentialProfit = (props: {
 		return POTENTIAL_PROFIT_DEFAULT_STATE;
 	}
 
-	const baseSizeBeingClosed = props.exitBaseSize.lte(props.currentPositionSize)
-		? props.exitBaseSize
-		: props.currentPositionSize;
+	const baseSizeBeingClosed = props.exitBaseSize;
 
 	// Notional size of amount being closed at entry and exit
 	notionalSizeAtEntry = baseSizeBeingClosed.mul(


### PR DESCRIPTION
Phase 2 of the module-by-module `common-ts` simplify+improve effort (standard in #351; Phase 1 in #352). Scope: the domain-utils cluster — `token`, `trading`, `markets`, `orders`, `positions`, `accounts`, `candles`, `orderbook`, `priority-fees`.

No public API changes — all symbols here are re-exported through the package entrypoint and preserved. 10 files, +47/−71.

## Behavior-preserving simplifications
- **`candles/Candle.ts`** — drop the constructor `try { … } catch (e) { throw e; }` (a rethrow-only no-op that was already `eslint-disable no-useless-catch`); remove a duplicated `logBadCandleProp()` call (every other branch calls it once).
- **`trading/pnl.ts`** — `baseSizeBeingClosed`'s ternary is unreachable after the `currentPositionSize.lt(exitBaseSize)` guard returns early, so it's always `exitBaseSize`.
- **`positions/open.ts`** — `ZERO.mul(PRICE_PRECISION)`/`ONE.mul(PRICE_PRECISION)` → `ZERO`/`PRICE_PRECISION`; `ZERO.add(orderTickSize)` → `orderTickSize` (BN is immutable); drop the now-unused `ONE` import.
- **`orderbook/index.ts`** — drop an identity alias `const priceToUse = price`.
- **`orders/filters.ts`** — drop two `&& true` no-ops; remove duplicated comments.
- **`trading/leverage.ts`** — remove step comments that restate the next line.
- **`trading/auction.ts`** — trim empty JSDoc `@param`/`@returns`; drop a commented-out `console.error`.

## Bug fixes
No internal callers / test refs (verified with `rg`); published via `utils/*`, so the fixes help downstream consumers:
- **`orders/sort.ts`** — the four exported sort functions (`sortUIMatchedOrderRecordAndAction`, `sortUIOrderActionRecords`, `sortUIOrderRecords`, `sortOrderRecords`) sorted **the caller's array in place** via `.sort()` then `.reverse()`. Now copy first (`[...records]`), matching the pattern `Candle` already uses.
- **`priority-fees/PriorityFeeStrategies.ts`** — `Math.max(...filteredSamples.map(…))` returns `-Infinity` when `filteredSamples` is empty, setting `LAST_SEEN_SLOT_IN_SAMPLES` to `-Infinity` so every later sample passes the `slot >` filter and gets reprocessed. Now guarded by a length check.
- **`markets/balances.ts`** — `getTotalBorrowsForMarket` fetched the same spot market account twice (`getSpotMarketAccount(marketAccount.marketIndex)`); reuse the local, matching `getTotalDepositsForMarket`.

## Deliberately skipped
Fail-open `try/catch` blocks at SDK/RPC boundaries (`validateLeverageChange`, `getMaxLeverageForMarketAccount`, `userExists`, `updateUserAccount`), `console` diagnostics (observable behavior), and inlining/removing exported or well-named helpers (public API + marginal value).

## Verification
- `bun run build` — clean
- `bun run test` — 106 passing (unchanged)
- `bun run circular-deps` — no cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)