### PR TITLE
refactor(common-ts): tidy infra utils (safe subset)

### DIFF
--- a/common-ts/src/utils/insuranceFund.ts
+++ b/common-ts/src/utils/insuranceFund.ts
@@ -13,8 +13,6 @@ import { UIMarket } from '../types/UIMarket';
 
 /**
  * Calculates the next APR for insurance fund staking
- * This function extracts the APR calculation logic from the insurance fund staking implementation
- * Reference: https://github.com/drift-labs/protocol-v2-mono/blob/ebbe7b8df7e81de59bd510a37d16f55d5c985ef5/ui/src/utils/insuranceFund.ts#L105
  *
  * @param spotMarket - Spot market account
  * @param vaultBalanceBigNum - Current vault balance as BigNum

--- a/common-ts/src/utils/priorityFees.ts
+++ b/common-ts/src/utils/priorityFees.ts
@@ -68,6 +68,10 @@ export const getHeliusPriorityFeeEstimate = async (
 			headers: { 'Content-Type': 'application/json' },
 		});
 
+		if (!response.ok) {
+			return undefined;
+		}
+
 		const result = (await response.json()) as {
 			min: number;
 			low: number;
@@ -76,10 +80,6 @@ export const getHeliusPriorityFeeEstimate = async (
 			veryHigh: number;
 			unsafeMax: number;
 		}[];
-
-		if (!response.ok) {
-			return undefined;
-		}
 
 		const feeLevelValues = result.map((result) => result?.[priorityFeeLevel]);
 

--- a/common-ts/src/utils/rpcLatency.ts
+++ b/common-ts/src/utils/rpcLatency.ts
@@ -17,7 +17,7 @@ export const getRpcWithLowestPing = async (rpcEndpoints: RpcEndpoint[]) => {
 	);
 
 	const validResults = results.filter(
-		(responseTime) => responseTime !== -1 && responseTime != null
+		(responseTime) => responseTime !== -1 && responseTime !== null
 	);
 
 	if (validResults.length <= 0) return undefined;

--- a/common-ts/src/utils/s3Buckets.ts
+++ b/common-ts/src/utils/s3Buckets.ts
@@ -110,7 +110,7 @@ export const getDateRangeFromSelection = (
 			to = dateToS3DateString(now);
 			break;
 		case 'custom':
-			if (!customOpts || customOpts?.year == undefined) {
+			if (!customOpts || customOpts.year == undefined) {
 				console.error(
 					'Requested custom date range without providing customOpts'
 				);

--- a/common-ts/src/utils/settings/settings.ts
+++ b/common-ts/src/utils/settings/settings.ts
@@ -65,7 +65,7 @@ export class VersionedSettingsHandler<T extends VersionedSettings> {
 	 * @param settings
 	 */
 	apply(settings: T) {
-		const sortedRules = this.rules.sort(
+		const sortedRules = [...this.rules].sort(
 			(a, b) => a.minVersionDiscriminator - b.minVersionDiscriminator
 		);
 
@@ -73,7 +73,7 @@ export class VersionedSettingsHandler<T extends VersionedSettings> {
 			if (!settings[rule.setting] || !settings.version) {
 				return true;
 			}
-			return rule.minVersionDiscriminator > settings?.version;
+			return rule.minVersionDiscriminator > settings.version;
 		});
 
 		const maxVersion = Math.max(


### PR DESCRIPTION
Phase 3 of the module-by-module `common-ts` simplify+improve effort (standard in #351; #352, #353 prior). Scope: top-level infra utils (`priorityFees`, `settings`, `s3Buckets`, `rpcLatency`, `insuranceFund`, etc.).

This is a deliberately small batch. Most findings in this cluster were in high-risk, thinly-tested code or out of scope, so they were left alone (see below). 5 files, +8/−10.

## Changes
- **`priorityFees.ts`** — check `response.ok` **before** `response.json()`, so a non-ok response returns `undefined` without risking a throw when the error body isn't JSON. Same return value on every path.
- **`settings/settings.ts`** — `[...this.rules].sort()` so `apply()` no longer mutates the instance's rule array in place; drop a redundant optional chain (`settings?.version`) on a required parameter that's accessed without `?.` two lines above.
- **`s3Buckets.ts`** — drop a redundant optional chain (`customOpts?.year` already guarded by `!customOpts ||`).
- **`rpcLatency.ts`** — `!= null` → `!== null` for consistency (`getResponseTime` never returns `undefined`).
- **`insuranceFund.ts`** — remove a stale pinned-commit reference comment to an archived repo.

## Deliberately skipped
- **`MultiplexWebSocket.ts`** — reconnection/lifecycle logic, thin test coverage; not worth the risk for marginal dead-enum/guard cleanups.
- **`pollingSequenceGuard.ts` / `SharedInterval.ts`** — concurrency- and emit-shape-sensitive; flagged changes would alter behavior.
- **Public-API signatures/members** — unused params (`priceImpact._oraclePrice`), unused exported methods (`ResultSlotIncrementer.resetAll`), default exports. Contract-preserving per the package CLAUDE.md.
- **Drift→Velocity domain URLs** (`priorityFees` FEE_ENDPOINT, `geoblock` worker) — flagged as stale, but changing them is out of scope for a simplification pass and needs the correct replacement URL.

## Verification
- `bun run build` — clean
- `bun run test` — 106 passing (unchanged)
- `bun run circular-deps` — no cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)