### PR TITLE
refactor(common-ts): simplify clients (safe subset)

### DIFF
--- a/common-ts/src/clients/candleClient.ts
+++ b/common-ts/src/clients/candleClient.ts
@@ -100,10 +100,6 @@ const getBaseDataApiUrl = (env: UIEnv) => {
 	return dataApiUrl.replace('https://', '');
 };
 
-// Cache for URL construction to prevent repeated string concatenation
-const urlCache = new Map<string, string>();
-const MAX_URL_CACHE_SIZE = 500;
-
 const getCandleFetchUrl = ({
 	env,
 	marketId,
@@ -113,29 +109,13 @@ const getCandleFetchUrl = ({
 }: CandleFetchUrlConfig) => {
 	const baseDataApiUrl = getBaseDataApiUrl(env);
 
-	// Cache key for this URL configuration
-	const cacheKey = `${marketId.key}-${resolution}-${countToFetch}-${env.key}-${
-		startTs ?? 'none'
-	}`;
-
-	if (urlCache.has(cacheKey)) {
-		return urlCache.get(cacheKey)!;
-	}
-
-	// Base URL without startTs parameter
 	let fetchUrl = `https://${baseDataApiUrl}/market/${getMarketSymbolForMarketId(
 		marketId,
 		env
 	)}/candles/${resolution}?limit=${Math.min(countToFetch, CANDLE_FETCH_LIMIT)}`;
 
-	// Only add startTs parameter if it's provided
 	if (startTs !== undefined) {
 		fetchUrl += `&startTs=${startTs}`;
-	}
-
-	// Cache the result if cache isn't too large
-	if (urlCache.size < MAX_URL_CACHE_SIZE) {
-		urlCache.set(cacheKey, fetchUrl);
 	}
 
 	return fetchUrl;
@@ -145,12 +125,7 @@ type CandleSubscriberEvents = {
 	'candle-update': JsonCandle;
 };
 
-// Separate event bus for candle events
-class CandleEventBus extends StrictEventEmitter<CandleSubscriberEvents> {
-	constructor() {
-		super();
-	}
-}
+class CandleEventBus extends StrictEventEmitter<CandleSubscriberEvents> {}
 
 // This class is reponsible for fetching candles from the data API's GET endpoint
 class CandleFetcher {
@@ -535,8 +510,6 @@ export class CandleClient {
 			eventBus: CandleEventBus;
 		}
 	> = new Map();
-
-	constructor() {}
 
 	public subscribe = async (
 		config: CandleSubscriptionConfig,

--- a/common-ts/src/clients/dataApiWsClient.ts
+++ b/common-ts/src/clients/dataApiWsClient.ts
@@ -72,13 +72,11 @@ export class DataApiWsClient {
 	private handleWsMessage = (
 		message: WsSubscriptionMessage<WsSubscriptionMessageType>
 	) => {
-		const parsedMessage = message;
-
-		switch (parsedMessage.type) {
+		switch (message.type) {
 			case 'update':
 				{
-					const candle = (parsedMessage as WsUpdateMessage).candle;
-					const trades = (parsedMessage as WsUpdateMessage).trades;
+					const candle = (message as WsUpdateMessage).candle;
+					const trades = (message as WsUpdateMessage).trades;
 					if (candle) this.candleSubject.next(candle);
 					if (trades) this.tradesSubject.next(trades);
 				}

--- a/common-ts/src/clients/marketDataFeed.ts
+++ b/common-ts/src/clients/marketDataFeed.ts
@@ -720,9 +720,6 @@ class SubscriptionManager {
 export class MarketDataFeed {
 	private static subscriptionManager = new SubscriptionManager();
 
-	constructor() {}
-
-	// Function overload, ensures the correct type is returned based on the config type
 	public static subscribe(
 		config: CandleSubscriptionConfig
 	): CandleSubscriberSubscription;

--- a/common-ts/src/clients/swiftClient.ts
+++ b/common-ts/src/clients/swiftClient.ts
@@ -10,25 +10,6 @@ import {
 	isVariant,
 } from '@velocity-exchange/sdk';
 
-// Cache for URL construction to prevent repeated string concatenation
-const swiftUrlCache = new Map<string, string>();
-const MAX_SWIFT_URL_CACHE_SIZE = 200;
-
-function getCachedUrl(baseUrl: string, endpoint: string): string {
-	const cacheKey = `${baseUrl}:${endpoint}`;
-
-	if (swiftUrlCache.has(cacheKey)) {
-		return swiftUrlCache.get(cacheKey)!;
-	}
-
-	const result = `${baseUrl}${endpoint}`;
-
-	if (swiftUrlCache.size < MAX_SWIFT_URL_CACHE_SIZE) {
-		swiftUrlCache.set(cacheKey, result);
-	}
-
-	return result;
-}
 import { Observable, Subscriber } from 'rxjs';
 import { allEnvDlog } from '../utils/logger';
 export type SwiftServerOrderProcessResponse = {
@@ -96,7 +77,7 @@ export class SwiftClient {
 					...this.getSwiftHeaders(),
 				});
 
-				fetch(getCachedUrl(this.baseUrl, url), {
+				fetch(`${this.baseUrl}${url}`, {
 					headers,
 				})
 					.then(async (response) => {
@@ -137,10 +118,7 @@ export class SwiftClient {
 			body: SwiftServerOrderProcessResponse;
 			status: number;
 		}>((res) => {
-			const postRequest = new Request(
-				getCachedUrl(this.baseUrl, url),
-				requestOptions
-			);
+			const postRequest = new Request(`${this.baseUrl}${url}`, requestOptions);
 
 			fetch(postRequest)
 				.then(async (response) => {

--- a/common-ts/src/clients/tvFeed.ts
+++ b/common-ts/src/clients/tvFeed.ts
@@ -360,8 +360,6 @@ export class VelocityTvFeed {
 		timestamp: number,
 		resolution: CandleResolution
 	) => {
-		const ROUND_UP = true;
-
 		const timestampMs = timestamp * 1000;
 		const candleLengthMs = Candle.resolutionStringToCandleLengthMs(resolution);
 
@@ -373,9 +371,7 @@ export class VelocityTvFeed {
 
 		const roundedDownTimestampMs = timestampMs - remainderMs;
 
-		const roundedTimestampMs = ROUND_UP
-			? roundedDownTimestampMs + candleLengthMs
-			: roundedDownTimestampMs;
+		const roundedTimestampMs = roundedDownTimestampMs + candleLengthMs;
 
 		return roundedTimestampMs / 1000;
 	};
@@ -561,7 +557,7 @@ export class VelocityTvFeed {
 		);
 
 		onResult(bars, {
-			noData: candlesResult.length === 0,
+			noData: false,
 		});
 
 		return;


### PR DESCRIPTION
Phase 4 of the module-by-module `common-ts` simplify+improve effort (standard in #351; #352–#354 prior). Scope: the `clients/*` cluster.

These are network/websocket clients, so this is a conservative pass — behavior-preserving cleanups only. 5 files, +8/−66.

## Changes
- **`swiftClient.ts`** — remove the `getCachedUrl` URL micro-cache and inline `` `${this.baseUrl}${url}` `` at both call sites. It cached two-short-string concatenations performed once per HTTP request — no benefit, just indirection.
- **`candleClient.ts`** — remove the equivalent URL micro-cache inside `getCandleFetchUrl` (one call per `fetch`); drop an empty `CandleEventBus` constructor (`constructor(){super();}`) and an empty `CandleClient` constructor.
- **`marketDataFeed.ts`** — drop an empty `MarketDataFeed` constructor; remove a comment restating a TS overload.
- **`dataApiWsClient.ts`** — drop the `parsedMessage = message` identity alias; use `message` directly.
- **`tvFeed.ts`** — `ROUND_UP` was a `const … = true` feeding a ternary, so the false branch was dead; collapse it. `noData: candlesResult.length === 0` is always `false` after the empty-result early return above it.

## Deliberately skipped
- **`redisClient.ts`** — flagged items (unawaited `set`, `@isRead` on a write, trailing chunk sleep) touch caching/`await`/throttling semantics that may be intentional; not safe to change blind.
- **`DlobWebsocketClient.ts`** — the `getCachedString` cache feeds subscription/result key routing; left untouched.
- All reconnection / error-handling / subscription-lifecycle logic.

## Verification
- `bun run build` — clean
- `bun run test` — 106 passing (incl. `marketDataFeed`)
- `bun run circular-deps` — no cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)