### PR TITLE
refactor(common-ts): simplify types & serializableTypes (safe subset)

### DIFF
--- a/common-ts/src/serializableTypes.ts
+++ b/common-ts/src/serializableTypes.ts
@@ -211,39 +211,13 @@ const PriceBigNumSerializeAndDeserializeFns = {
 	Deserialize: PriceBigNumDeserializationFn,
 };
 
-const FundingRateBigNumSerializationFn = (target: BigNum | BN) =>
-	target
-		? target instanceof BigNum
-			? target.print()
-			: target.toString()
-		: undefined;
-const FundingRateBigNumDeserializationFn = (val: string | number) =>
-	val !== undefined
-		? typeof val === 'string'
-			? BigNum.from(val.replace('.', ''), PRICE_PRECISION_EXP)
-			: BigNum.fromPrint(val.toString(), PRICE_PRECISION_EXP)
-		: undefined;
-const FundingRateBigNumSerializeAndDeserializeFns = {
-	Serialize: FundingRateBigNumSerializationFn,
-	Deserialize: FundingRateBigNumDeserializationFn,
-};
+// Funding rate and bank cumulative interest serialize identically to price
+// (same PRICE_PRECISION_EXP); alias rather than duplicate the functions.
+const FundingRateBigNumSerializeAndDeserializeFns =
+	PriceBigNumSerializeAndDeserializeFns;
 
-const BankCumulativeInterestBigNumSerializationFn = (target: BigNum | BN) =>
-	target
-		? target instanceof BigNum
-			? target.print()
-			: target.toString()
-		: undefined;
-const BankCumulativeInterestBigNumDeserializationFn = (val: string | number) =>
-	val !== undefined
-		? typeof val === 'string'
-			? BigNum.from(val.replace('.', ''), PRICE_PRECISION_EXP)
-			: BigNum.fromPrint(val.toString(), PRICE_PRECISION_EXP)
-		: undefined;
-const BankCumulativeInterestBigNumSerializeAndDeserializeFns = {
-	Serialize: BankCumulativeInterestBigNumSerializationFn,
-	Deserialize: BankCumulativeInterestBigNumDeserializationFn,
-};
+const BankCumulativeInterestBigNumSerializeAndDeserializeFns =
+	PriceBigNumSerializeAndDeserializeFns;
 
 const ReferralVolumeBigNumSerializationFn = (target: BigNum | BN) =>
 	target
@@ -338,7 +312,7 @@ function validateEventTypeOnDeserialize<
 		);
 
 		// If it's just undefined then we're happy to set it for them
-		instance.eventType = expectedEventType as string; // added 'as string' to accommodate older typescript version errors
+		instance.eventType = expectedEventType as string;
 	}
 }
 
@@ -363,7 +337,7 @@ function validateEventTypeOnSerialize<
 		);
 
 		// If it's just undefined then we're happy to set it for them
-		json.eventType = expectedEventType as string; // added 'as string' to accommodate older typescript version errors
+		json.eventType = expectedEventType as string;
 	}
 }
 
@@ -2051,7 +2025,7 @@ export class UISerializableInsuranceFundRecord extends SerializableInsuranceFund
 			instance.insuranceVaultAmountBefore.precision = precisionToUse;
 			instance.amount.precision = precisionToUse;
 		} catch (e) {
-			//console.error('Error in insurance fund serializer', e);
+			// ignore: fall back to default precision if market lookup fails
 		}
 	}
 }

--- a/common-ts/src/types/UIMarket.ts
+++ b/common-ts/src/types/UIMarket.ts
@@ -111,7 +111,6 @@ export class UIMarket {
 		//@ts-ignore
 		const market = markets.find((m) => m.marketIndex === marketIndex);
 
-		// TODO: should we purposely throw an error here? Or construct a default market?
 		invariant(
 			market,
 			`Market not found for type: ${marketId.marketTypeStr}, market index: ${marketIndex}`
@@ -154,14 +153,11 @@ export class UIMarket {
 	}
 
 	static checkIsPredictionMarket(marketConfig: PerpMarketConfig) {
-		if (!(marketConfig as PerpMarketConfig).category) {
+		if (!marketConfig.category) {
 			return false;
 		}
 
-		return (
-			(marketConfig as PerpMarketConfig).category?.includes('Prediction') ??
-			false
-		);
+		return marketConfig.category.includes('Prediction');
 	}
 
 	get isSpot() {
@@ -258,11 +254,7 @@ export class UIMarket {
 	}
 
 	private getMarketSymbol(): MarketSymbol {
-		if (this.marketId.isPerp) {
-			return this.market.symbol as MarketSymbol;
-		} else {
-			return this.market.symbol as MarketSymbol;
-		}
+		return this.market.symbol as MarketSymbol;
 	}
 
 	private getMarketDisplaySymbol(): MarketDisplaySymbol {
@@ -274,9 +266,8 @@ export class UIMarket {
 				case MAIN_POOL_ID:
 					return marketConfig.symbol as MarketDisplaySymbol;
 				case JLP_POOL_ID:
-					return `${marketConfig.symbol.split('-')[0]}` as MarketDisplaySymbol;
 				case LST_POOL_ID:
-					return `${marketConfig.symbol.split('-')[0]}` as MarketDisplaySymbol;
+					return marketConfig.symbol.split('-')[0] as MarketDisplaySymbol;
 				case EXPONENT_POOL_ID: {
 					/*
 					Example market symbol conversions:
@@ -295,7 +286,7 @@ export class UIMarket {
 					) as MarketDisplaySymbol;
 				}
 				case SACRED_POOL_ID:
-					return `${marketConfig.symbol.split('-')[0]}` as MarketDisplaySymbol;
+					return marketConfig.symbol.split('-')[0] as MarketDisplaySymbol;
 				default:
 					return marketConfig.symbol as MarketDisplaySymbol;
 			}


### PR DESCRIPTION
Phase 5 of the module-by-module `common-ts` simplify+improve effort (standard in #351; #352–#355 prior). Scope: `types/*`, `constants/*`, `serializableTypes.ts`.

No public API or wire-format changes. 2 files, +14/−49.

## `types/UIMarket.ts`
- **`getMarketSymbol`** — both `if/else` branches returned the same expression; collapsed to one return.
- **`checkIsPredictionMarket`** — dropped two casts to the parameter's own type (`PerpMarketConfig`) and the post-guard `?.` / `?? false` (after `if (!category) return false`, `category` is truthy).
- **`getMarketDisplaySymbol`** — merged the identical `JLP_POOL_ID` / `LST_POOL_ID` switch arms; dropped no-op `` `${…}` `` wrapping of values that are already strings.
- Removed a stale TODO ("should we throw here?") answered by the `invariant()` on the next line.

## `serializableTypes.ts`
- **Serializer dedup** — `FundingRateBigNum*` and `BankCumulativeInterestBigNum*` were byte-for-byte identical to `PriceBigNum*` (same `PRICE_PRECISION_EXP`). Aliased the two `*SerializeAndDeserializeFns` to `PriceBigNumSerializeAndDeserializeFns` instead of duplicating ~24 lines. The named exports the decorators reference are preserved, and the wire format is unchanged (same object).
- Removed a commented-out `console.error` and two stale `// added 'as string' to accommodate older typescript version errors` comments.

## Flagged, not fixed
`UISerializableUserSnapshotRecord.totalAccountValue` is typed `BigNum` but is missing the `@autoserializeUsing(QuoteBigNumSerializeAndDeserializeFns)` decorator that every sibling `BigNum` field has, so it likely deserializes as `BN`. Fixing it would change deserialization output, so it's left for a deliberate decision rather than folded into a simplification pass.

## Verification
- `bun run build` — clean
- `bun run test` — 106 passing
- `bun run circular-deps` — no cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)