### PR TITLE
refactor(common-ts): remove dead code & cruft from drift cluster

### DIFF
--- a/common-ts/src/drift/Velocity/clients/AuthorityVelocity/SubscriptionManager.ts
+++ b/common-ts/src/drift/Velocity/clients/AuthorityVelocity/SubscriptionManager.ts
@@ -262,7 +262,6 @@ export class SubscriptionManager {
 		this.updatePollingDlobIntervals(
 			filteredUserInvolvedMarkets.map((market) => market.key),
 			filteredUserNotInvolvedMarkets.map((market) => market.key)
-			// this.selectedTradeMarket
 		);
 	}
 

--- a/common-ts/src/drift/Velocity/clients/AuthorityVelocity/VelocityL2OrderbookManager.ts
+++ b/common-ts/src/drift/Velocity/clients/AuthorityVelocity/VelocityL2OrderbookManager.ts
@@ -162,8 +162,6 @@ export class VelocityL2OrderbookManager {
 		try {
 			const parsedData = this.tryParse(data) as RawL2Output;
 
-			// TODO: result slot incrementer
-
 			const deserializedOrderbook = deserializeL2Response(parsedData);
 			this._orderbook = deserializedOrderbook;
 			this.updatesSubject$.next(deserializedOrderbook);
@@ -176,7 +174,7 @@ export class VelocityL2OrderbookManager {
 	 * Get orderbook data for a specific market
 	 */
 	public getOrderbookData(): L2WithOracleAndMarketData | null {
-		return this._orderbook || null;
+		return this._orderbook;
 	}
 
 	/**

--- a/common-ts/src/drift/Velocity/clients/AuthorityVelocity/VelocityOperations/index.ts
+++ b/common-ts/src/drift/Velocity/clients/AuthorityVelocity/VelocityOperations/index.ts
@@ -792,16 +792,3 @@ export class VelocityOperations {
 		return txSig;
 	}
 }
-
-/**
- * TODO:
- * - transfer between subaccounts
- * - close position?
- * - close multiple positions
- * - edit open order
- * - create user only
- *
- * - open spot order
- * - rename subaccount
- * - withdraw dust positions
- */

--- a/common-ts/src/drift/Velocity/clients/AuthorityVelocity/index.ts
+++ b/common-ts/src/drift/Velocity/clients/AuthorityVelocity/index.ts
@@ -667,8 +667,6 @@ export class AuthorityVelocity {
 		]);
 
 		this.subscriptionManager.subscribeToAllUsersUpdates();
-
-		// TODO: subscribe to oracle price updates from velocity client?
 	}
 
 	public async unsubscribe() {

--- a/common-ts/src/drift/Velocity/stores/MarkPriceCache.ts
+++ b/common-ts/src/drift/Velocity/stores/MarkPriceCache.ts
@@ -15,8 +15,6 @@ export class MarkPriceCache {
 	private _store: MarkPriceLookup = {};
 	private updatesSubject$ = new Subject<MarkPriceLookup>();
 
-	constructor() {}
-
 	get store() {
 		return { ...this._store };
 	}

--- a/common-ts/src/drift/Velocity/stores/OraclePriceCache.ts
+++ b/common-ts/src/drift/Velocity/stores/OraclePriceCache.ts
@@ -8,8 +8,6 @@ export class OraclePriceCache {
 	private _store: OraclePriceLookup = {};
 	private updatesSubject$ = new Subject<OraclePriceLookup>();
 
-	constructor() {}
-
 	get store() {
 		return { ...this._store };
 	}

--- a/common-ts/src/drift/base/actions/spot/deposit.ts
+++ b/common-ts/src/drift/base/actions/spot/deposit.ts
@@ -102,13 +102,6 @@ export const createDepositTxn = async ({
 	initSwiftAccount: _initSwiftAccount,
 	externalWallet,
 }: CreateDepositTxnParams): Promise<Transaction | VersionedTransaction> => {
-	// const authority = user.getUserAccount().authority;
-	// const associatedDepositTokenAddress =
-	// 	await getTokenAddressForDepositAndWithdraw(
-	// 		spotMarketConfig.mint,
-	// 		authority
-	// 	);
-
 	let finalDepositAmount = amount;
 
 	if (isMaxBorrowRepayment) {

--- a/common-ts/src/drift/base/actions/trade/openPerpOrder/openSwiftOrder/index.ts
+++ b/common-ts/src/drift/base/actions/trade/openPerpOrder/openSwiftOrder/index.ts
@@ -253,11 +253,6 @@ export const prepSwiftOrder = ({
 
 	const signedMsgOrderUuid = generateSignedMsgUuid();
 
-	console.log(
-		'DEBUG swift prep orderParams.isolatedPositionDeposit',
-		orderParams.isolatedPositionDeposit?.toString()
-	);
-
 	const baseSignedMsgOrderParamsMessage = {
 		signedMsgOrderParams: mainOrderParams,
 		uuid: signedMsgOrderUuid,

--- a/common-ts/src/drift/cli.ts
+++ b/common-ts/src/drift/cli.ts
@@ -4,7 +4,6 @@ import {
 	BN,
 	loadKeypair,
 	PositionDirection,
-	OrderType,
 	PostOnlyParams,
 	SwapMode,
 	BASE_PRECISION,
@@ -136,31 +135,6 @@ function parseDirection(direction: string): PositionDirection {
 		throw new Error(
 			`Invalid direction: ${direction}. Use 'long', 'short', 'buy', or 'sell'`
 		);
-	}
-}
-
-/**
- * Parse order type string to OrderType
- */
-function _parseOrderType(orderType: string): OrderType {
-	const normalized = orderType.toLowerCase();
-	switch (normalized) {
-		case 'limit':
-			return OrderType.LIMIT;
-		case 'market':
-			return OrderType.MARKET;
-		case 'oracle':
-			return OrderType.ORACLE;
-		case 'trigger_market':
-		case 'stopmarket':
-			return OrderType.TRIGGER_MARKET;
-		case 'trigger_limit':
-		case 'stoplimit':
-			return OrderType.TRIGGER_LIMIT;
-		default:
-			throw new Error(
-				`Invalid order type: ${orderType}. Use 'limit', 'market', 'oracle', 'trigger_market', or 'trigger_limit'`
-			);
 	}
 }
 
@@ -844,7 +818,6 @@ async function openPerpNonMarketOrderCommand(args: CliArgs): Promise<void> {
 	console.log(`🔄 Reduce Only: ${reduceOnly}`);
 	console.log(`📌 Post Only: ${postOnly} (${ENUM_UTILS.toStr(postOnlyEnum)})`);
 
-	// Just call the main method - it will handle both approaches internally
 	const orderTxn = await centralServerVelocity.getOpenPerpNonMarketOrderTxn({
 		userAccountPublicKey: userAccountPubkey,
 		marketIndex,
@@ -1325,8 +1298,7 @@ async function swapCommand(args: CliArgs): Promise<void> {
 		swapModeEnum === 'ExactIn' ? fromMarketIndex : toMarketIndex;
 
 	// Get the appropriate precision for the amount based on the market
-	const isMainnet = true; // Default to mainnet, could be made configurable
-	const precision = getMarketPrecision(precisionMarketIndex, isMainnet);
+	const precision = getMarketPrecision(precisionMarketIndex, true);
 	const amountBN = parseAmount(amount, precision);
 
 	console.log('--- 🔄 Swap Transaction ---');


### PR DESCRIPTION
Phase 6 (final) of the module-by-module `common-ts` simplify+improve effort (standard in #351; #352–#356 prior). Scope: the `drift/**` cluster (~12.8k LOC — the largest and most complex).

This is the most conservative pass of the series. The drift test suite is **broken on `master`** (a pre-existing type error in `accountManagement.test.ts`), so there's no behavioral safety net here — I limited changes to dead code and comment cruft only, and touched **no** order/transaction/trading logic. 9 files, +2/−64.

## Changes
- **`cli.ts`** — remove the unused file-private `_parseOrderType` function (verified zero callers) and its now-unused `OrderType` import; inline `const isMainnet = true`; drop a comment restating the call below it.
- **`base/actions/spot/deposit.ts`** — remove a commented-out `authority`/`associatedDepositTokenAddress` block (the live code uses `createDepositIxs`).
- **`openPerpOrder/openSwiftOrder/index.ts`** — remove a leftover `console.log('DEBUG ...')`.
- **`Velocity/stores/MarkPriceCache.ts` & `OraclePriceCache.ts`** — drop empty `constructor() {}` (TS auto-generates).
- **`AuthorityVelocity/VelocityL2OrderbookManager.ts`** — `return this._orderbook || null` → `return this._orderbook` (the field is typed `… | null`, so `|| null` is a no-op); drop an inline `// TODO: result slot incrementer`.
- **`AuthorityVelocity/VelocityOperations/index.ts`** — remove a dangling end-of-file `TODO:` comment block attached to no code.
- **`AuthorityVelocity/SubscriptionManager.ts`** — remove a commented-out call argument.
- **`AuthorityVelocity/index.ts`** — remove a speculative trailing TODO.

## Verification
- `bun run build` — clean
- `bun run test` — 106 passing
- `bun run circular-deps` — no cycles
- `bun run test:drift` — fails with the **same** pre-existing `accountManagement.test.ts(227/259)` type error as `master`; no new failures introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)