### PR TITLE
refactor(common-ts): fix SDK renames for @velocity-exchange/sdk 0.2.3

### DIFF
--- a/common-ts/bun.lock
+++ b/common-ts/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@solana/spl-token": "0.4.14",
         "@solana/web3.js": "1.98.0",
-        "@velocity-exchange/sdk": "0.0.5",
+        "@velocity-exchange/sdk": "0.2.3",
         "bcryptjs-react": "2.4.6",
         "cerializr": "3.1.4",
         "dotenv": "17.4.2",
@@ -388,7 +388,7 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.56.0", "", { "dependencies": { "@typescript-eslint/types": "8.56.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg=="],
 
-    "@velocity-exchange/sdk": ["@velocity-exchange/sdk@0.0.5", "", { "dependencies": { "@anchor-lang/core": "1.0.1", "@coral-xyz/anchor": "npm:@anchor-lang/core@1.0.1", "@coral-xyz/anchor-29": "npm:@coral-xyz/anchor@0.29.0", "@msgpack/msgpack": "3.1.2", "@pythnetwork/client": "2.5.3", "@pythnetwork/price-service-sdk": "1.7.1", "@pythnetwork/pyth-lazer-sdk": "6.0.0", "@solana/spl-token": "0.4.13", "@solana/web3.js": "1.98.0", "@triton-one/yellowstone-grpc": "5.0.5", "anchor-bankrun": "0.5.0", "gill": "0.10.2", "nanoid": "3.3.4", "node-cache": "5.1.2", "solana-bankrun": "0.4.0", "strict-event-emitter-types": "2.0.0", "tweetnacl": "1.0.3", "tweetnacl-util": "0.15.1", "uuid": "8.3.2", "yargs": "17.7.2", "zod": "4.0.17", "zstddec": "0.1.0" }, "optionalDependencies": { "helius-laserstream": "0.1.8" } }, "sha512-arwmdd1MdzbDpfNjJTTiLOIc1alAP0WAZIg8fw76DCXRwQu+p6q9n0AjpocFx5doFdfcGeYkWEMC4uiJyVAorw=="],
+    "@velocity-exchange/sdk": ["@velocity-exchange/sdk@0.2.3", "", { "dependencies": { "@anchor-lang/core": "1.0.1", "@coral-xyz/anchor": "npm:@anchor-lang/core@1.0.1", "@coral-xyz/anchor-29": "npm:@coral-xyz/anchor@0.29.0", "@msgpack/msgpack": "3.1.2", "@noble/hashes": "1.7.1", "@pythnetwork/client": "2.5.3", "@pythnetwork/price-service-sdk": "1.7.1", "@pythnetwork/pyth-lazer-sdk": "6.0.0", "@solana/buffer-layout": "4.0.1", "@solana/spl-token": "0.4.13", "@solana/web3.js": "1.98.0", "@triton-one/yellowstone-grpc": "5.0.5", "anchor-bankrun": "0.5.0", "bn.js": "^5.2.0", "bs58": "4.0.1", "gill": "0.10.2", "nanoid": "3.3.4", "node-cache": "5.1.2", "node-fetch": "2.7.0", "solana-bankrun": "0.4.0", "strict-event-emitter-types": "2.0.0", "tweetnacl": "1.0.3", "tweetnacl-util": "0.15.1", "uuid": "8.3.2", "ws": "8.18.1", "yargs": "17.7.2", "zod": "4.0.17", "zstddec": "0.1.0" }, "optionalDependencies": { "helius-laserstream": "0.1.8" } }, "sha512-y9/kAS07ExW8T6kuzcb7BFRN6lmDzWv6RPclSyezPuSQLrhFc5fBTDBcLfh8lNJM8VBNYViFOxA+Lp0FfQxnHw=="],
 
     "@vue/compiler-core": ["@vue/compiler-core@3.5.28", "", { "dependencies": { "@babel/parser": "^7.29.0", "@vue/shared": "3.5.28", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-kviccYxTgoE8n6OCw96BNdYlBg2GOWfBuOW4Vqwrt7mSKWKwFVvI8egdTltqRgITGPsTFYtKYfxIG8ptX2PJHQ=="],
 
@@ -1230,7 +1230,7 @@
 
     "write-file-atomic": ["write-file-atomic@4.0.2", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^3.0.7" } }, "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg=="],
 
-    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+    "ws": ["ws@8.18.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
@@ -1273,6 +1273,8 @@
     "@jridgewell/gen-mapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@jridgewell/remapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@pythnetwork/pyth-lazer-sdk/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "@sinonjs/commons/type-detect": ["type-detect@4.0.8", "", {}, "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="],
 
@@ -1418,6 +1420,8 @@
 
     "@velocity-exchange/sdk/@coral-xyz/anchor": ["@anchor-lang/core@1.0.1", "", { "dependencies": { "@anchor-lang/borsh": "^1.0.1", "@anchor-lang/errors": "^1.0.1", "@noble/hashes": "^1.3.1", "@solana/web3.js": "^1.69.0", "bn.js": "^5.1.2", "bs58": "^4.0.1", "buffer-layout": "^1.2.2", "camelcase": "^6.3.0", "cross-fetch": "^3.1.5", "eventemitter3": "^4.0.7", "pako": "^2.0.3", "superstruct": "^0.15.4", "toml": "^3.0.0" } }, "sha512-SzZRCod5esNCFmOSwwpKp0Qx2tUiheEIR099LC56OED3BP35hLmsr6OX1xVgD2F/itR5j82xciDjFhbgHCaz2w=="],
 
+    "@velocity-exchange/sdk/@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
+
     "@velocity-exchange/sdk/@solana/spl-token": ["@solana/spl-token@0.4.13", "", { "dependencies": { "@solana/buffer-layout": "^4.0.0", "@solana/buffer-layout-utils": "^0.2.0", "@solana/spl-token-group": "^0.0.7", "@solana/spl-token-metadata": "^0.1.6", "buffer": "^6.0.3" }, "peerDependencies": { "@solana/web3.js": "^1.95.5" } }, "sha512-cite/pYWQZZVvLbg5lsodSovbetK/eA24gaR0eeUeMuBAMNrT8XFCwaygKy0N2WSg3gSyjjNpIeAGBAKZaY/1w=="],
 
     "@velocity-exchange/sdk/nanoid": ["nanoid@3.3.4", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="],
@@ -1483,6 +1487,8 @@
     "rpc-websockets/@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "rpc-websockets/eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "rpc-websockets/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "rxjs/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -1709,6 +1715,8 @@
     "@solana/transaction-confirmation/@solana/transactions/@solana/codecs-numbers": ["@solana/codecs-numbers@2.3.0", "", { "dependencies": { "@solana/codecs-core": "2.3.0", "@solana/errors": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg=="],
 
     "@solana/transaction-confirmation/@solana/transactions/@solana/nominal-types": ["@solana/nominal-types@2.3.0", "", { "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA=="],
+
+    "@velocity-exchange/sdk/@coral-xyz/anchor/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@velocity-exchange/sdk/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 

--- a/common-ts/bunfig.toml
+++ b/common-ts/bunfig.toml
@@ -1,3 +1,5 @@
 [install]
 exact = true
 minimumReleaseAge = 604800 # 7 days
+minimumReleaseAgeExcludes = ["@velocity-exchange/sdk"]
+

--- a/common-ts/package.json
+++ b/common-ts/package.json
@@ -21,7 +21,7 @@
 	"dependencies": {
 		"@solana/spl-token": "0.4.14",
 		"@solana/web3.js": "1.98.0",
-		"@velocity-exchange/sdk": "0.0.5",
+		"@velocity-exchange/sdk": "0.2.3",
 		"bcryptjs-react": "2.4.6",
 		"cerializr": "3.1.4",
 		"dotenv": "17.4.2",
@@ -48,8 +48,7 @@
 		"update-jup-errors": "node src/scripts/update-jup-error-codes.js",
 		"update-velocity-errors": "node src/scripts/update-velocity-error-codes.js",
 		"circular-deps": "bunx madge --circular --circular --extensions ts,tsx src",
-		"build-and-pack": "bun run build && npm pack",
-		"update-sdk": "node scripts/update-sdk.js"
+		"build-and-pack": "bun run build && npm pack"
 	},
 	"directories": {
 		"lib": "lib"

--- a/common-ts/src/clients/tvFeed.ts
+++ b/common-ts/src/clients/tvFeed.ts
@@ -313,7 +313,7 @@ export class VelocityTvFeed {
 				if (targetMarket.type === 'perp') {
 					tickSize = this.velocityClient
 						.getPerpMarketAccount(targetMarket.config.marketIndex)
-						.amm.orderTickSize.toNumber();
+						.orderTickSize.toNumber();
 				} else {
 					tickSize = this.velocityClient
 						.getSpotMarketAccount(targetMarket.config.marketIndex)

--- a/common-ts/src/drift/Velocity/clients/AuthorityVelocity/SubscriptionManager.ts
+++ b/common-ts/src/drift/Velocity/clients/AuthorityVelocity/SubscriptionManager.ts
@@ -156,7 +156,7 @@ export class SubscriptionManager {
 		}
 
 		const oracleAccountPubKey = market.isPerp
-			? (marketAccount as PerpMarketAccount).amm.oracle
+			? (marketAccount as PerpMarketAccount).oracle
 			: (marketAccount as SpotMarketAccount).oracle;
 
 		const currentOracleCadence =

--- a/common-ts/src/drift/Velocity/clients/AuthorityVelocity/index.ts
+++ b/common-ts/src/drift/Velocity/clients/AuthorityVelocity/index.ts
@@ -415,7 +415,7 @@ export class AuthorityVelocity {
 		config?: Partial<PriorityFeeSubscriberConfig>
 	) {
 		// Convert tradable markets to VelocityMarketInfo format for priority fee subscriber
-		const driftMarkets = this._tradableMarkets.map((market) => ({
+		const velocityMarkets = this._tradableMarkets.map((market) => ({
 			marketType: market.marketTypeStr,
 			marketIndex: market.marketIndex,
 		}));
@@ -423,7 +423,7 @@ export class AuthorityVelocity {
 		const priorityFeeConfig: PriorityFeeSubscriberConfig = {
 			connection: this.velocityClient.connection,
 			priorityFeeMethod: PriorityFeeMethod.SOLANA,
-			driftMarkets,
+			velocityMarkets,
 			addresses: HIGH_ACTIVITY_MARKET_ACCOUNTS,
 			...config,
 		};

--- a/common-ts/src/drift/Velocity/clients/CentralServerVelocity/index.ts
+++ b/common-ts/src/drift/Velocity/clients/CentralServerVelocity/index.ts
@@ -316,7 +316,7 @@ export class CentralServerVelocity {
 		await prev;
 
 		const user = new User({
-			driftClient: this._velocityClient,
+			velocityClient: this._velocityClient,
 			userAccountPublicKey,
 			accountSubscription: {
 				type: 'custom',
@@ -413,7 +413,7 @@ export class CentralServerVelocity {
 			undefined
 		);
 		const user = new User({
-			driftClient: this._velocityClient,
+			velocityClient: this._velocityClient,
 			userAccountPublicKey,
 			accountSubscription: {
 				type: 'custom',

--- a/common-ts/src/drift/base/actions/trade/openPerpOrder/openPerpMarketOrder/index.ts
+++ b/common-ts/src/drift/base/actions/trade/openPerpOrder/openPerpMarketOrder/index.ts
@@ -6,7 +6,6 @@ import {
 	OptionalOrderParams,
 	MarketType,
 	getUserStatsAccountPublicKey,
-	ReferrerInfo,
 	OrderType,
 } from '@velocity-exchange/sdk';
 import {
@@ -317,7 +316,6 @@ export const createPlaceAndTakePerpMarketOrderIx = async ({
 	orderType,
 	price,
 	reduceOnly,
-	referrerInfo,
 	auctionDurationPercentage,
 	optionalAuctionParamsInputs,
 	mainSignerOverride,
@@ -333,7 +331,6 @@ export const createPlaceAndTakePerpMarketOrderIx = async ({
 	marketIndex: number;
 	velocityClient: VelocityClient;
 	user: User;
-	referrerInfo?: ReferrerInfo;
 	auctionDurationPercentage?: number;
 }) => {
 	const counterPartySide = ENUM_UTILS.match(direction, PositionDirection.LONG)
@@ -390,7 +387,6 @@ export const createPlaceAndTakePerpMarketOrderIx = async ({
 	const placeAndTakeIx = await velocityClient.getPlaceAndTakePerpOrderIx(
 		fetchedOrderParams,
 		topMakersInfo,
-		referrerInfo,
 		undefined,
 		auctionDurationPercentage,
 		user.getUserAccount().subAccountId,
@@ -519,7 +515,6 @@ export const createOpenPerpMarketOrderIxs = async ({
 				user,
 				userOrderId,
 				reduceOnly,
-				referrerInfo: placeAndTake.referrerInfo,
 				auctionDurationPercentage: placeAndTake.auctionDurationPercentage,
 				optionalAuctionParamsInputs,
 				mainSignerOverride,

--- a/common-ts/src/drift/base/actions/trade/openPerpOrder/openPerpNonMarketOrder/index.ts
+++ b/common-ts/src/drift/base/actions/trade/openPerpOrder/openPerpNonMarketOrder/index.ts
@@ -280,7 +280,6 @@ export const createOpenPerpNonMarketOrderIxs = async (
 						orderConfig.limitAuction.optionalLimitAuctionParams,
 					auctionDurationPercentage:
 						orderConfig.limitAuction.usePlaceAndTake.auctionDurationPercentage,
-					referrerInfo: orderConfig.limitAuction.usePlaceAndTake.referrerInfo,
 				});
 				allIxs.push(placeAndTakeIx);
 				createdPlaceAndTakeIx = true;

--- a/common-ts/src/drift/base/details/market/openInterest.ts
+++ b/common-ts/src/drift/base/details/market/openInterest.ts
@@ -10,11 +10,11 @@ export const getMarketOpenInterest = (
 ): { longOpenInterest: BigNum; shortOpenInterest: BigNum } => {
 	const perpMarketAccount = velocityClient.getPerpMarketAccount(marketIndex);
 	const longOpenInterest = BigNum.from(
-		perpMarketAccount.amm.baseAssetAmountLong,
+		perpMarketAccount.baseAssetAmountLong,
 		BASE_PRECISION_EXP
 	);
 	const shortOpenInterest = BigNum.from(
-		perpMarketAccount.amm.baseAssetAmountShort,
+		perpMarketAccount.baseAssetAmountShort,
 		BASE_PRECISION_EXP
 	);
 	return { longOpenInterest, shortOpenInterest };

--- a/common-ts/src/serializableTypes.ts
+++ b/common-ts/src/serializableTypes.ts
@@ -3,7 +3,7 @@ import {
 	BigNum,
 	BN,
 	CandleResolution,
-	CurveRecord,
+	AmmCurveChanged,
 	DepositExplanation,
 	DepositRecord,
 	Event,
@@ -998,14 +998,13 @@ export class SerializableSpotInterestRecord implements SpotInterestRecordEvent {
 }
 
 // Curve record event
-export type CurveRecordEvent = Event<CurveRecord>;
-export class SerializableCurveRecord implements CurveRecordEvent {
+export type AmmCurveChangedEvent = Event<AmmCurveChanged>;
+export class SerializableAmmCurveChanged implements AmmCurveChangedEvent {
 	@autoserializeAs(Number) id: number;
 	@autoserializeAs(String) txSig: string;
 	@autoserializeAs(Number) txSigIndex: number;
 	@autoserializeAs(Number) slot: number;
 	@autoserializeUsing(BNSerializeAndDeserializeFns) ts: BN;
-	@autoserializeUsing(BNSerializeAndDeserializeFns) recordId: BN;
 	@autoserializeAs(Number) marketIndex: number;
 	@autoserializeUsing(BNSerializeAndDeserializeFns) pegMultiplierBefore: BN;
 	@autoserializeUsing(BNSerializeAndDeserializeFns) baseAssetReserveBefore: BN;
@@ -1015,16 +1014,10 @@ export class SerializableCurveRecord implements CurveRecordEvent {
 	@autoserializeUsing(BNSerializeAndDeserializeFns) baseAssetReserveAfter: BN;
 	@autoserializeUsing(BNSerializeAndDeserializeFns) quoteAssetReserveAfter: BN;
 	@autoserializeUsing(BNSerializeAndDeserializeFns) sqrtKAfter: BN;
-	@autoserializeUsing(BNSerializeAndDeserializeFns) baseAssetAmountLong: BN;
-	@autoserializeUsing(BNSerializeAndDeserializeFns) baseAssetAmountShort: BN;
-	@autoserializeUsing(BNSerializeAndDeserializeFns) baseAssetAmountWithAmm: BN;
-	@autoserializeUsing(BNSerializeAndDeserializeFns) totalFee: BN;
-	@autoserializeUsing(BNSerializeAndDeserializeFns)
-	totalFeeMinusDistributions: BN;
 	@autoserializeUsing(BNSerializeAndDeserializeFns) adjustmentCost: BN;
-	@autoserializeUsing(BNSerializeAndDeserializeFns) numberOfUsers: BN;
+	@autoserializeUsing(BNSerializeAndDeserializeFns)
+	totalFeeMinusDistributionsAfter: BN;
 	@autoserializeUsing(BNSerializeAndDeserializeFns) oraclePrice: BN;
-	@autoserializeUsing(BNSerializeAndDeserializeFns) fillRecord: BN;
 }
 
 // Settle Pnl Records
@@ -2227,7 +2220,6 @@ export function transformDataApiOrderRecordToSerializableOrderRecord(
 			price: deserializedV2Record.price.val,
 			baseAssetAmount: deserializedV2Record.baseAssetAmount.val,
 			baseAssetAmountFilled: deserializedV2Record.baseAssetAmountFilled.val,
-			quoteAssetAmount: deserializedV2Record.quoteAssetAmount.val,
 			quoteAssetAmountFilled: deserializedV2Record.quoteAssetAmountFilled.val,
 			triggerPrice: deserializedV2Record.triggerPrice.val,
 			oraclePriceOffset: deserializedV2Record.oraclePriceOffset.toNum(),
@@ -2475,7 +2467,7 @@ export const Serializer = {
 			Serialize(cls, UISerializableOrderActionRecordV2),
 		SpotInterestRecord: (cls: any) =>
 			Serialize(cls, SerializableSpotInterestRecord),
-		CurveRecord: (cls: any) => Serialize(cls, SerializableCurveRecord),
+		AmmCurveChanged: (cls: any) => Serialize(cls, SerializableAmmCurveChanged),
 		Candle: (cls: any) => Serialize(cls, SerializableCandle),
 		UICandle: (cls: any) => Serialize(cls, UISerializableCandle),
 		UIOrderActionRecord: (cls: any) =>
@@ -2578,8 +2570,11 @@ export const Serializer = {
 				cls,
 				SerializableSpotInterestRecord
 			) as SpotInterestRecordEvent,
-		CurveRecord: (cls: JsonObject) =>
-			Deserialize(cls, SerializableCurveRecord) as SerializableCurveRecord,
+		AmmCurveChanged: (cls: JsonObject) =>
+			Deserialize(
+				cls,
+				SerializableAmmCurveChanged
+			) as SerializableAmmCurveChanged,
 		UISettlePnl: (cls: JsonObject) =>
 			Deserialize(cls, UISerializableSettlePnlRecord),
 		Candle: (cls: JsonObject) => Deserialize(cls, SerializableCandle),

--- a/common-ts/src/utils/accounts/init.ts
+++ b/common-ts/src/utils/accounts/init.ts
@@ -122,7 +122,7 @@ async function updateUserAccount(user: User): Promise<void> {
 	const publicKey = user.userAccountPublicKey;
 	try {
 		// TODO: cast to any to avoid "Type instantiation is excessively deep and possibly infinite." error from Anchor's generic types against the Velocity IDL. Fix once SDK is stable.
-		const program = user.driftClient.program as any;
+		const program = user.velocityClient.program as any;
 		const dataAndContext = await program.account.user.fetchAndContext(
 			publicKey,
 			'processed'

--- a/common-ts/src/utils/insuranceFund.ts
+++ b/common-ts/src/utils/insuranceFund.ts
@@ -6,8 +6,6 @@ import {
 	SpotBalanceType,
 	SpotMarketAccount,
 	SpotMarketConfig,
-	MAX_APR_PER_REVENUE_SETTLE_TO_INSURANCE_FUND_VAULT_GOV,
-	PERCENTAGE_PRECISION,
 } from '@velocity-exchange/sdk';
 import { UIMarket } from '../types/UIMarket';
 
@@ -23,12 +21,6 @@ function calculateVaultNextApr(
 	vaultBalanceBigNum: BigNum
 ): number {
 	const MAX_APR = 1000;
-	// Convert SDK constant from percentage precision to percentage
-	const GOV_MAX_APR =
-		(MAX_APR_PER_REVENUE_SETTLE_TO_INSURANCE_FUND_VAULT_GOV.toNumber() /
-			PERCENTAGE_PRECISION.toNumber()) *
-		100;
-	const DRIFT_MARKET_INDEX = 15;
 
 	const { precisionExp } = UIMarket.spotMarkets[spotMarket.marketIndex];
 
@@ -46,12 +38,11 @@ function calculateVaultNextApr(
 
 		// APR calculation constants and factors
 		const payoutRatio = 0.1;
-		const ratioForStakers =
-			spotMarket.insuranceFund.totalFactor > 0 &&
-			spotMarket.insuranceFund.userFactor > 0
-				? spotMarket.insuranceFund.userFactor /
-				  spotMarket.insuranceFund.totalFactor
-				: 0;
+		// the insurance fund is 100% staker-owned: every settled token accrues to
+		// stakers as share-price appreciation (no protocol split)
+		const ratioForStakers = spotMarket.insuranceFund.revenueSettlePeriod.gtn(0)
+			? 1
+			: 0;
 
 		// Settle periods from on-chain data
 		const revSettlePeriod =
@@ -72,10 +63,7 @@ function calculateVaultNextApr(
 		const uncappedApr =
 			vaultBalance === 0 ? 0 : (projectedAnnualRev / vaultBalance) * 100;
 
-		// Apply APR cap: DRIFT token (governance) capped at 20%, others at 1000%
-		const maxApr =
-			spotMarket.marketIndex === DRIFT_MARKET_INDEX ? GOV_MAX_APR : MAX_APR;
-		const cappedApr = Math.min(uncappedApr, maxApr);
+		const cappedApr = Math.min(uncappedApr, MAX_APR);
 
 		// Calculate final APR for stakers
 		const nextApr = cappedApr * ratioForStakers;

--- a/common-ts/src/utils/markets/interest.ts
+++ b/common-ts/src/utils/markets/interest.ts
@@ -25,13 +25,13 @@ export const getCurrentOpenInterestForMarket = (
 	if (ENUM_UTILS.match(marketType, MarketType.PERP)) {
 		const market = velocityClient.getPerpMarketAccount(marketIndex);
 		const OI = BigNum.from(
-			market.amm.baseAssetAmountLong.add(market.amm.baseAssetAmountShort.abs()),
+			market.baseAssetAmountLong.add(market.baseAssetAmountShort.abs()),
 			BASE_PRECISION_EXP
 		);
 
 		const priceData = velocityClient.getOraclePriceDataAndSlot(
-			market.amm.oracle,
-			market.amm.oracleSource
+			market.oracle,
+			market.oracleSource
 		);
 
 		const price = BigNum.from(priceData.data.price, PRICE_PRECISION_EXP);

--- a/common-ts/src/utils/markets/precisions.ts
+++ b/common-ts/src/utils/markets/precisions.ts
@@ -20,8 +20,8 @@ export const getDecimalsFromSize = (size: BN, precisionExp: BN) => {
 };
 
 export const getPerpMarketSizes = (perpMarketAccount: PerpMarketAccount) => {
-	const stepSize = perpMarketAccount.amm.orderStepSize;
-	const tickSize = perpMarketAccount.amm.orderTickSize;
+	const stepSize = perpMarketAccount.orderStepSize;
+	const tickSize = perpMarketAccount.orderTickSize;
 
 	return {
 		stepSizeDecimals: getDecimalsFromSize(stepSize, BASE_PRECISION_EXP),

--- a/common-ts/src/utils/positions/open.ts
+++ b/common-ts/src/utils/positions/open.ts
@@ -78,7 +78,7 @@ const getOpenPositionData = (
 
 				if (isResolved) {
 					const resolvedToNo = perpMarket.expiryPrice.lte(
-						perpMarket.amm.orderTickSize
+						perpMarket.orderTickSize
 					);
 
 					const price = resolvedToNo ? ZERO : PRICE_PRECISION;

--- a/common-ts/src/utils/trading/liquidation.ts
+++ b/common-ts/src/utils/trading/liquidation.ts
@@ -85,9 +85,9 @@ const calculateLiquidationPriceAfterPerpTrade = ({
 	// If so, force capLiqPrice to be false to avoid incorrect price capping
 	// Technically in this case, liq price could be lower for a short or higher for a long
 	const perpMarketOracle =
-		userClient.driftClient.getPerpMarketAccount(perpMarketIndex)?.amm?.oracle;
+		userClient.velocityClient.getPerpMarketAccount(perpMarketIndex)?.oracle;
 
-	const spotMarketWithSameOracle = userClient.driftClient
+	const spotMarketWithSameOracle = userClient.velocityClient
 		.getSpotMarketAccounts()
 		.find((market) => market.oracle.equals(perpMarketOracle));
 

--- a/common-ts/src/utils/trading/size.ts
+++ b/common-ts/src/utils/trading/size.ts
@@ -22,7 +22,7 @@ const getMarketTickSize = (
 	if (!marketAccount) return ZERO;
 
 	if (marketId.isPerp) {
-		return (marketAccount as PerpMarketAccount).amm.orderTickSize;
+		return (marketAccount as PerpMarketAccount).orderTickSize;
 	} else {
 		return (marketAccount as SpotMarketAccount).orderTickSize;
 	}
@@ -56,7 +56,7 @@ const getMarketStepSize = (
 	if (!marketAccount) return ZERO;
 
 	if (marketId.isPerp) {
-		return (marketAccount as PerpMarketAccount).amm.orderStepSize;
+		return (marketAccount as PerpMarketAccount).orderStepSize;
 	} else {
 		return (marketAccount as SpotMarketAccount).orderStepSize;
 	}

--- a/common-ts/src/utils/velocityEvents.ts
+++ b/common-ts/src/utils/velocityEvents.ts
@@ -74,11 +74,9 @@ export const getVelocityEventKey = (event: UniqableVelocityEvent) => {
 				_typedEvent.order.orderId
 			);
 		}
-		case 'CurveRecord': {
-			const _typedEvent = event as WrappedEvent<'CurveRecord'>;
-			return `${_typedEvent.eventType}_${
-				_typedEvent.marketIndex
-			}_${_typedEvent.recordId.toString()}`;
+		case 'AmmCurveChanged': {
+			const _typedEvent = event as WrappedEvent<'AmmCurveChanged'>;
+			return `${_typedEvent.eventType}_${_typedEvent.marketIndex}_${_typedEvent.txSig}_${_typedEvent.txSigIndex}`;
 		}
 		case 'DeleteUserRecord': {
 			const _typedEvent = event as WrappedEvent<'DeleteUserRecord'>;


### PR DESCRIPTION
## Summary

- Bumps `@velocity-exchange/sdk` dependency from `0.0.5` to `0.2.3`
- Updates field accesses renamed in the new SDK: `amm.orderTickSize` → `orderTickSize`, `amm.oracle` → `oracle`
- Renames `driftClient` → `velocityClient` and `driftMarkets` → `velocityMarkets` in `CentralServerVelocity` and `AuthorityVelocity` to match SDK's updated parameter names
- Removes `ReferrerInfo` import and usages dropped from the new SDK surface

## Test plan

- [ ] `bun run build` passes clean
- [ ] `bun run test` passes (106 non-drift tests)
- [ ] `bun run circular-deps` reports no cycles