### PR TITLE
ci(icons): set up release-please and npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ jobs:
       posthog-types--release_created: ${{ steps.rp.outputs['posthog-types--release_created'] }}
       posthog-types--version: ${{ steps.rp.outputs['posthog-types--version'] }}
       posthog-types--tag_name: ${{ steps.rp.outputs['posthog-types--tag_name'] }}
+      icons--release_created: ${{ steps.rp.outputs['icons--release_created'] }}
+      icons--version: ${{ steps.rp.outputs['icons--version'] }}
+      icons--tag_name: ${{ steps.rp.outputs['icons--tag_name'] }}
     steps:
       - name: Mint App token
         id: app-token
@@ -70,6 +73,33 @@ jobs:
 
       - name: Run tests
         run: bun run test:ci
+
+      - name: Publish to npm
+        run: npm publish --access=public --provenance
+
+  publish-icons:
+    needs: release-please
+    if: ${{ needs.release-please.outputs['icons--release_created'] == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write # npm Trusted Publishing OIDC
+    defaults:
+      run:
+        working-directory: ./icons
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.release-please.outputs['icons--tag_name'] }}
+
+      - uses: ./.github/actions/setup-common-ts
+        with:
+          registry-url: 'https://registry.npmjs.org'
+          working-directory: ./icons
+
+      - name: Build
+        run: bun run build
 
       - name: Publish to npm
         run: npm publish --access=public --provenance
@@ -143,7 +173,7 @@ jobs:
             -d "{\"event_type\":\"drift-common-update\",\"client_payload\":{\"version\":\"${VERSION}\"}}"
 
   notify-failure:
-    needs: [release-please, publish-common-ts, dispatch-downstream]
+    needs: [release-please, publish-common-ts, publish-icons, dispatch-downstream]
     if: ${{ failure() || cancelled() }}
     runs-on: ubicloud
     permissions: {}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
 	"common-ts": "0.0.4",
-	"posthog-types": "0.1.0"
+	"posthog-types": "0.1.0",
+	"icons": "1.0.0"
 }

--- a/icons/package.json
+++ b/icons/package.json
@@ -1,54 +1,63 @@
 {
-  "name": "@drift-labs/icons",
-  "version": "1.0.0",
-  "description": "Convert Figma icons to React components",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "files": [
-    "dist"
-  ],
-  "types": "dist/index.d.ts",
-  "license": "MIT",
-  "sideEffects": false,
-  "scripts": {
-    "build-icons-script": "tsc ./src/generate.ts --esModuleInterop --skipLibCheck",
-    "icons": "node ./src/generate.js",
-    "icons:debug": "node --inspect-brk --inspect=2233 ./src/generate.js",
-    "clean": "rm -rf dist",
-    "clean-icons": "rm -rf src/icons/components/*",
-    "build": "rm -rf dist && tsc -v && tsc",
-    "build:rollup": "rm -rf dist && tsc -v && rollup -c"
-  },
-  "private": true,
-  "dependencies": {
-    "react": "19.0.0-rc-02c0e824-20241028"
-  },
-  "devDependencies": {
-    "@rollup/plugin-commonjs": "22.0.2",
-    "@rollup/plugin-node-resolve": "14.1.0",
-    "@rollup/plugin-typescript": "8.5.0",
-    "@svgr/core": "5.5.0",
-    "@svgr/plugin-prettier": "5.5.0",
-    "@svgr/plugin-svgo": "5.5.0",
-    "@types/fs-extra": "9.0.13",
-    "@types/node": "17.0.8",
-    "@types/react": "npm:types-react@19.0.0-rc.1",
-    "axios": "0.31.1",
-    "chalk": "4.1.2",
-    "dotenv": "10.0.0",
-    "figma-api-exporter": "0.0.2",
-    "fs-extra": "10.0.0",
-    "nodemon": "1.18.4",
-    "rollup": "2.80.0",
-    "rollup-plugin-dts": "4.2.2",
-    "ts-node": "10.4.0",
-    "tslib": "2.4.1",
-    "typescript": "4.5.4"
-  },
-  "keywords": [
-    "react",
-    "figma to react",
-    "icons",
-    "icon generator"
-  ]
+	"name": "@velocity-exchange/icons",
+	"version": "1.0.0",
+	"description": "Convert Figma icons to React components",
+	"main": "dist/index.js",
+	"module": "dist/index.js",
+	"files": [
+		"dist"
+	],
+	"types": "dist/index.d.ts",
+	"license": "MIT",
+	"author": "Velocity Exchange",
+	"homepage": "https://www.drift.trade/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/drift-labs/drift-common/tree/master/icons"
+	},
+	"sideEffects": false,
+	"scripts": {
+		"build-icons-script": "tsc ./src/generate.ts --esModuleInterop --skipLibCheck",
+		"icons": "node ./src/generate.js",
+		"icons:debug": "node --inspect-brk --inspect=2233 ./src/generate.js",
+		"clean": "rm -rf dist",
+		"clean-icons": "rm -rf src/icons/components/*",
+		"build": "rm -rf dist && tsc -v && tsc",
+		"build:rollup": "rm -rf dist && tsc -v && rollup -c",
+		"prepublishOnly": "bun run build"
+	},
+	"dependencies": {
+		"react": "19.0.0-rc-02c0e824-20241028"
+	},
+	"devDependencies": {
+		"@rollup/plugin-commonjs": "22.0.2",
+		"@rollup/plugin-node-resolve": "14.1.0",
+		"@rollup/plugin-typescript": "8.5.0",
+		"@svgr/core": "5.5.0",
+		"@svgr/plugin-prettier": "5.5.0",
+		"@svgr/plugin-svgo": "5.5.0",
+		"@types/fs-extra": "9.0.13",
+		"@types/node": "17.0.8",
+		"@types/react": "npm:types-react@19.0.0-rc.1",
+		"axios": "0.31.1",
+		"chalk": "4.1.2",
+		"dotenv": "10.0.0",
+		"figma-api-exporter": "0.0.2",
+		"fs-extra": "10.0.0",
+		"nodemon": "1.18.4",
+		"rollup": "2.80.0",
+		"rollup-plugin-dts": "4.2.2",
+		"ts-node": "10.4.0",
+		"tslib": "2.4.1",
+		"typescript": "4.5.4"
+	},
+	"keywords": [
+		"react",
+		"figma to react",
+		"icons",
+		"icon generator"
+	],
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -26,6 +26,11 @@
 			"package-name": "@drift-labs/posthog-types",
 			"component": "posthog-types",
 			"changelog-path": "CHANGELOG.md"
+		},
+		"icons": {
+			"package-name": "@velocity-exchange/icons",
+			"component": "icons",
+			"changelog-path": "CHANGELOG.md"
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add the `icons` package to release-please: new entry in `release-please-config.json` (`@velocity-exchange/icons`) and a `1.0.0` seed in `.release-please-manifest.json`.
- Add a `publish-icons` job to the release workflow, mirroring `publish-common-ts` (checkout at the icons tag → reusable setup action → `bun run build` → `npm publish --provenance` via OIDC). Wired into `notify-failure`.
- Make `icons/package.json` publishable: drop `"private": true`, fix `main`/`module`/`types` to the actual `tsc` dist output (they pointed at `dist/cjs`/`dist/esm`, which no build produced), and add `repository`/`author`/`homepage`/`publishConfig`/`prepublishOnly`.

## Notes
- Before the first automated release, `@velocity-exchange/icons` must be published once manually and registered for npm Trusted Publishing (OIDC) on npmjs.com, same as common-ts.
- `react` is still a hard `dependency` pinned to an RC build; converting it to a `peerDependency` is a sensible follow-up but left out here to avoid a runtime-behavior change.

## Test plan
- [x] `bun run build` in `icons/` produces `dist/index.js` + `dist/index.d.ts`
- [x] `npm pack --dry-run` yields `velocity-exchange-icons-1.0.0.tgz` with `main`/`types` present and all icon components included
- [ ] After merge: confirm release-please opens an `icons` release PR on the next `feat`/`fix` commit touching `icons/`