### PR TITLE
refactor(common-ts): update @velocity-exchange/sdk to 0.2.4 and reconcile

### DIFF
--- a/common-ts/bun.lock
+++ b/common-ts/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@solana/spl-token": "0.4.14",
         "@solana/web3.js": "1.98.0",
-        "@velocity-exchange/sdk": "0.2.3",
+        "@velocity-exchange/sdk": "0.2.4",
         "bcryptjs-react": "2.4.6",
         "cerializr": "3.1.4",
         "dotenv": "17.4.2",
@@ -388,7 +388,7 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.56.0", "", { "dependencies": { "@typescript-eslint/types": "8.56.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg=="],
 
-    "@velocity-exchange/sdk": ["@velocity-exchange/sdk@0.2.3", "", { "dependencies": { "@anchor-lang/core": "1.0.1", "@coral-xyz/anchor": "npm:@anchor-lang/core@1.0.1", "@coral-xyz/anchor-29": "npm:@coral-xyz/anchor@0.29.0", "@msgpack/msgpack": "3.1.2", "@noble/hashes": "1.7.1", "@pythnetwork/client": "2.5.3", "@pythnetwork/price-service-sdk": "1.7.1", "@pythnetwork/pyth-lazer-sdk": "6.0.0", "@solana/buffer-layout": "4.0.1", "@solana/spl-token": "0.4.13", "@solana/web3.js": "1.98.0", "@triton-one/yellowstone-grpc": "5.0.5", "anchor-bankrun": "0.5.0", "bn.js": "^5.2.0", "bs58": "4.0.1", "gill": "0.10.2", "nanoid": "3.3.4", "node-cache": "5.1.2", "node-fetch": "2.7.0", "solana-bankrun": "0.4.0", "strict-event-emitter-types": "2.0.0", "tweetnacl": "1.0.3", "tweetnacl-util": "0.15.1", "uuid": "8.3.2", "ws": "8.18.1", "yargs": "17.7.2", "zod": "4.0.17", "zstddec": "0.1.0" }, "optionalDependencies": { "helius-laserstream": "0.1.8" } }, "sha512-y9/kAS07ExW8T6kuzcb7BFRN6lmDzWv6RPclSyezPuSQLrhFc5fBTDBcLfh8lNJM8VBNYViFOxA+Lp0FfQxnHw=="],
+    "@velocity-exchange/sdk": ["@velocity-exchange/sdk@0.2.4", "", { "dependencies": { "@anchor-lang/core": "1.0.1", "@coral-xyz/anchor": "npm:@anchor-lang/core@1.0.1", "@coral-xyz/anchor-29": "npm:@coral-xyz/anchor@0.29.0", "@msgpack/msgpack": "3.1.2", "@noble/hashes": "1.7.1", "@pythnetwork/client": "2.5.3", "@pythnetwork/price-service-sdk": "1.7.1", "@pythnetwork/pyth-lazer-sdk": "6.0.0", "@solana/buffer-layout": "4.0.1", "@solana/spl-token": "0.4.13", "@solana/web3.js": "1.98.0", "@triton-one/yellowstone-grpc": "5.0.5", "anchor-bankrun": "0.5.0", "bn.js": "^5.2.0", "bs58": "4.0.1", "gill": "0.10.2", "nanoid": "3.3.4", "node-cache": "5.1.2", "node-fetch": "2.7.0", "solana-bankrun": "0.4.0", "strict-event-emitter-types": "2.0.0", "tweetnacl": "1.0.3", "tweetnacl-util": "0.15.1", "uuid": "8.3.2", "ws": "8.18.1", "yargs": "17.7.2", "zod": "4.0.17", "zstddec": "0.1.0" }, "optionalDependencies": { "helius-laserstream": "0.1.8" } }, "sha512-O9KaDBEZqpcxCN6a7PDUxlIkU2c9PRboilYOV/dImPgC29g1Y+AQ5aFnn7vwdUCHGwv8ifRMHjh1ICt9E76Z6g=="],
 
     "@vue/compiler-core": ["@vue/compiler-core@3.5.28", "", { "dependencies": { "@babel/parser": "^7.29.0", "@vue/shared": "3.5.28", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-kviccYxTgoE8n6OCw96BNdYlBg2GOWfBuOW4Vqwrt7mSKWKwFVvI8egdTltqRgITGPsTFYtKYfxIG8ptX2PJHQ=="],
 

--- a/common-ts/package.json
+++ b/common-ts/package.json
@@ -21,7 +21,7 @@
 	"dependencies": {
 		"@solana/spl-token": "0.4.14",
 		"@solana/web3.js": "1.98.0",
-		"@velocity-exchange/sdk": "0.2.3",
+		"@velocity-exchange/sdk": "0.2.4",
 		"bcryptjs-react": "2.4.6",
 		"cerializr": "3.1.4",
 		"dotenv": "17.4.2",

--- a/common-ts/src/clients/swiftClient.ts
+++ b/common-ts/src/clients/swiftClient.ts
@@ -327,7 +327,7 @@ export class SwiftClient {
 				program.account.signedMsgUserOrders.coder.accounts
 			);
 		const decodedAccount = accountDecoder(
-			'SignedMsgUserOrders',
+			'signedMsgUserOrders',
 			ordersAccount.data
 		) as SignedMsgUserOrdersAccount;
 		allEnvDlog(

--- a/common-ts/src/constants/autogenerated/velocityErrors.json
+++ b/common-ts/src/constants/autogenerated/velocityErrors.json
@@ -18,10 +18,7 @@
 		"InsufficientCollateral": {
 			"code": 6003,
 			"name": "InsufficientCollateral",
-			"msg": "Insufficient collateral",
-			"toast": {
-				"description": "You don't have enough collateral, try using less leverage or deposit more collateral."
-			}
+			"msg": "Insufficient collateral"
 		},
 		"SufficientCollateral": {
 			"code": 6004,
@@ -31,21 +28,17 @@
 		"MaxNumberOfPositions": {
 			"code": 6005,
 			"name": "MaxNumberOfPositions",
-			"msg": "Max number of positions taken",
-			"toast": {
-				"message": "Maximum Positions Exceeded",
-				"description": "Close a position then try again or open it in another subaccount."
-			}
+			"msg": "Max number of positions taken"
 		},
 		"AdminControlsPricesDisabled": {
 			"code": 6006,
 			"name": "AdminControlsPricesDisabled",
 			"msg": "Admin Controls Prices Disabled"
 		},
-		"MarketIndexNotInitialized": {
+		"MarketDelisted": {
 			"code": 6007,
-			"name": "MarketIndexNotInitialized",
-			"msg": "Market Index Not Initialized"
+			"name": "MarketDelisted",
+			"msg": "Market Delisted"
 		},
 		"MarketIndexAlreadyInitialized": {
 			"code": 6008,
@@ -85,18 +78,12 @@
 		"SlippageOutsideLimit": {
 			"code": 6015,
 			"name": "SlippageOutsideLimit",
-			"msg": "Slippage Outside Limit Price",
-			"toast": {
-				"message": "Slippage limit exceeded."
-			}
+			"msg": "Slippage Outside Limit Price"
 		},
 		"OrderSizeTooSmall": {
 			"code": 6016,
 			"name": "OrderSizeTooSmall",
-			"msg": "Order Size Too Small",
-			"toast": {
-				"message": "Order size is too small."
-			}
+			"msg": "Order Size Too Small"
 		},
 		"InvalidUpdateK": {
 			"code": 6017,
@@ -111,10 +98,7 @@
 		"MathError": {
 			"code": 6019,
 			"name": "MathError",
-			"msg": "Math Error",
-			"toast": {
-				"message": "Math Error"
-			}
+			"msg": "Math Error"
 		},
 		"BnConversionError": {
 			"code": 6020,
@@ -124,10 +108,7 @@
 		"ClockUnavailable": {
 			"code": 6021,
 			"name": "ClockUnavailable",
-			"msg": "Clock unavailable",
-			"toast": {
-				"message": "Blockchain Clock Unavailable"
-			}
+			"msg": "Clock unavailable"
 		},
 		"UnableToLoadOracle": {
 			"code": 6022,
@@ -137,35 +118,22 @@
 		"PriceBandsBreached": {
 			"code": 6023,
 			"name": "PriceBandsBreached",
-			"msg": "Price Bands Breached",
-			"toast": {
-				"message": "Market Specific Price Bands Breached",
-				"description": "https://docs.drift.trade/risk-and-safety/protocol-guard-rails"
-			}
+			"msg": "Price Bands Breached"
 		},
 		"ExchangePaused": {
 			"code": 6024,
 			"name": "ExchangePaused",
-			"msg": "Exchange is paused",
-			"toast": {
-				"message": "The Exchange is currently paused."
-			}
+			"msg": "Exchange is paused"
 		},
 		"InvalidWhitelistToken": {
 			"code": 6025,
 			"name": "InvalidWhitelistToken",
-			"msg": "Invalid whitelist token",
-			"toast": {
-				"message": "Invalid V2 Alpha Ticket Passed"
-			}
+			"msg": "Invalid whitelist token"
 		},
 		"WhitelistTokenNotFound": {
 			"code": 6026,
 			"name": "WhitelistTokenNotFound",
-			"msg": "Whitelist token not found",
-			"toast": {
-				"message": "No V2 Alpha Ticket Found"
-			}
+			"msg": "Whitelist token not found"
 		},
 		"InvalidDiscountToken": {
 			"code": 6027,
@@ -180,137 +148,147 @@
 		"ReferrerNotFound": {
 			"code": 6029,
 			"name": "ReferrerNotFound",
-			"msg": "Referrer not found",
-			"toast": {
-				"message": "Referrer Account not passed in Transaction",
-				"description": ""
-			}
+			"msg": "Referrer not found"
 		},
 		"ReferrerStatsNotFound": {
 			"code": 6030,
 			"name": "ReferrerStatsNotFound",
-			"msg": "ReferrerNotFound",
-			"toast": {
-				"message": "Referrer Stats not passed in Transaction",
-				"description": ""
-			}
+			"msg": "ReferrerNotFound"
 		},
 		"ReferrerMustBeWritable": {
 			"code": 6031,
 			"name": "ReferrerMustBeWritable",
-			"msg": "ReferrerMustBeWritable",
-			"toast": {
-				"message": "Incorrect Write Permission on Referrer Account for Transaction",
-				"description": ""
-			}
+			"msg": "ReferrerMustBeWritable"
 		},
 		"ReferrerStatsMustBeWritable": {
 			"code": 6032,
 			"name": "ReferrerStatsMustBeWritable",
-			"msg": "ReferrerMustBeWritable",
-			"toast": {
-				"message": "Incorrect Write Permission on Referrer Stats for Transaction",
-				"description": ""
-			}
+			"msg": "ReferrerMustBeWritable"
 		},
 		"ReferrerAndReferrerStatsAuthorityUnequal": {
 			"code": 6033,
 			"name": "ReferrerAndReferrerStatsAuthorityUnequal",
-			"msg": "ReferrerAndReferrerStatsAuthorityUnequal",
-			"toast": {
-				"message": "Inconsistent Referrer Information Passed for Transaction",
-				"description": ""
-			}
+			"msg": "ReferrerAndReferrerStatsAuthorityUnequal"
 		},
 		"InvalidReferrer": {
 			"code": 6034,
 			"name": "InvalidReferrer",
-			"msg": "InvalidReferrer",
-			"toast": {
-				"message": "Incorrect Referrer Information Passed for Transaction",
-				"description": ""
-			}
+			"msg": "InvalidReferrer"
 		},
 		"InvalidOracle": {
 			"code": 6035,
 			"name": "InvalidOracle",
-			"msg": "InvalidOracle",
-			"toast": {
-				"message": "Oracle Information deemed Invalid for Action. Please try again in a few minutes",
-				"description": ""
-			}
+			"msg": "InvalidOracle"
 		},
 		"OracleNotFound": {
 			"code": 6036,
 			"name": "OracleNotFound",
-			"msg": "OracleNotFound",
-			"toast": {
-				"message": "Oracle Information not properly passed for Transaction",
-				"description": ""
-			}
+			"msg": "OracleNotFound"
 		},
 		"LiquidationsBlockedByOracle": {
 			"code": 6037,
 			"name": "LiquidationsBlockedByOracle",
-			"msg": "Liquidations Blocked By Oracle",
-			"toast": {
-				"message": "Liquidation cannot proceed with Oracle Price",
-				"description": ""
-			}
+			"msg": "Liquidations Blocked By Oracle"
 		},
 		"MaxDeposit": {
 			"code": 6038,
 			"name": "MaxDeposit",
-			"msg": "Can not deposit more than max deposit",
-			"toast": {
-				"message": "Spot Market has Hit Max Deposit Limit",
-				"description": ""
-			}
+			"msg": "Can not deposit more than max deposit"
 		},
 		"CantDeleteUserWithCollateral": {
 			"code": 6039,
 			"name": "CantDeleteUserWithCollateral",
-			"msg": "Can not delete user that still has collateral",
-			"toast": {
-				"message": "Cannot Delete User Account",
-				"description": "User subaccount still has outstanding assets and/or liabilities"
-			}
+			"msg": "Can not delete user that still has collateral"
 		},
 		"InvalidFundingProfitability": {
 			"code": 6040,
 			"name": "InvalidFundingProfitability",
-			"msg": "AMM funding out of bounds pnl",
-			"toast": {
-				"message": "Funding Rate Update",
-				"description": ""
-			}
+			"msg": "AMM funding out of bounds pnl"
 		},
 		"CastingFailure": {
 			"code": 6041,
 			"name": "CastingFailure",
-			"msg": "Casting Failure",
-			"toast": {
-				"message": "Numerical Casting Failure",
-				"description": ""
-			}
+			"msg": "Casting Failure"
 		},
 		"InvalidOrder": {
 			"code": 6042,
 			"name": "InvalidOrder",
-			"msg": "Invalid Order",
-			"toast": {
-				"message": "Placed Order is Invalid",
-				"description": "Make sure you've configured your order parameters appropriately"
-			}
+			"msg": "InvalidOrder"
+		},
+		"InvalidOrderMaxTs": {
+			"code": 6043,
+			"name": "InvalidOrderMaxTs",
+			"msg": "InvalidOrderMaxTs"
+		},
+		"InvalidOrderMarketType": {
+			"code": 6044,
+			"name": "InvalidOrderMarketType",
+			"msg": "InvalidOrderMarketType"
+		},
+		"InvalidOrderForInitialMarginReq": {
+			"code": 6045,
+			"name": "InvalidOrderForInitialMarginReq",
+			"msg": "InvalidOrderForInitialMarginReq"
+		},
+		"InvalidOrderNotRiskReducing": {
+			"code": 6046,
+			"name": "InvalidOrderNotRiskReducing",
+			"msg": "InvalidOrderNotRiskReducing"
+		},
+		"InvalidOrderSizeTooSmall": {
+			"code": 6047,
+			"name": "InvalidOrderSizeTooSmall",
+			"msg": "InvalidOrderSizeTooSmall"
+		},
+		"InvalidOrderNotStepSizeMultiple": {
+			"code": 6048,
+			"name": "InvalidOrderNotStepSizeMultiple",
+			"msg": "InvalidOrderNotStepSizeMultiple"
+		},
+		"InvalidOrderBaseQuoteAsset": {
+			"code": 6049,
+			"name": "InvalidOrderBaseQuoteAsset",
+			"msg": "InvalidOrderBaseQuoteAsset"
+		},
+		"InvalidOrderIOC": {
+			"code": 6050,
+			"name": "InvalidOrderIOC",
+			"msg": "InvalidOrderIOC"
+		},
+		"InvalidOrderPostOnly": {
+			"code": 6051,
+			"name": "InvalidOrderPostOnly",
+			"msg": "InvalidOrderPostOnly"
+		},
+		"InvalidOrderIOCPostOnly": {
+			"code": 6052,
+			"name": "InvalidOrderIOCPostOnly",
+			"msg": "InvalidOrderIOCPostOnly"
+		},
+		"InvalidOrderTrigger": {
+			"code": 6053,
+			"name": "InvalidOrderTrigger",
+			"msg": "InvalidOrderTrigger"
+		},
+		"InvalidOrderAuction": {
+			"code": 6054,
+			"name": "InvalidOrderAuction",
+			"msg": "InvalidOrderAuction"
+		},
+		"InvalidOrderOracleOffset": {
+			"code": 6055,
+			"name": "InvalidOrderOracleOffset",
+			"msg": "InvalidOrderOracleOffset"
+		},
+		"InvalidOrderMinOrderSize": {
+			"code": 6056,
+			"name": "InvalidOrderMinOrderSize",
+			"msg": "InvalidOrderMinOrderSize"
 		},
 		"PlacePostOnlyLimitFailure": {
 			"code": 6057,
 			"name": "PlacePostOnlyLimitFailure",
-			"msg": "Failed to Place Post-Only Limit Order",
-			"toast": {
-				"message": "Placed Post-Only Order crosses the spread",
-				"description": "Must alter maker price or disable post only flag to fill when crossing"
-			}
+			"msg": "Failed to Place Post-Only Limit Order"
 		},
 		"UserHasNoOrder": {
 			"code": 6058,
@@ -320,20 +298,12 @@
 		"OrderAmountTooSmall": {
 			"code": 6059,
 			"name": "OrderAmountTooSmall",
-			"msg": "Order Amount Too Small",
-			"toast": {
-				"message": "Order amount too small",
-				"description": ""
-			}
+			"msg": "Order Amount Too Small"
 		},
 		"MaxNumberOfOrders": {
 			"code": 6060,
 			"name": "MaxNumberOfOrders",
-			"msg": "Max number of orders taken",
-			"toast": {
-				"message": "This SubAccount has already has Max Number of Open Orders (32)",
-				"description": "Cancelled orders to place more or create a new subaccount."
-			}
+			"msg": "Max number of orders taken"
 		},
 		"OrderDoesNotExist": {
 			"code": 6061,
@@ -368,11 +338,7 @@
 		"UserCantReferThemselves": {
 			"code": 6067,
 			"name": "UserCantReferThemselves",
-			"msg": "User cant refer themselves",
-			"toast": {
-				"message": "Referral Error",
-				"description": "You can't refer yourself."
-			}
+			"msg": "User cant refer themselves"
 		},
 		"DidNotReceiveExpectedReferrer": {
 			"code": 6068,
@@ -424,19 +390,19 @@
 			"name": "CouldNotLoadMarketData",
 			"msg": "CouldNotLoadMarketData"
 		},
-		"MarketNotFound": {
+		"PerpMarketNotFound": {
 			"code": 6078,
-			"name": "MarketNotFound",
-			"msg": "MarketNotFound"
+			"name": "PerpMarketNotFound",
+			"msg": "PerpMarketNotFound"
 		},
 		"InvalidMarketAccount": {
 			"code": 6079,
 			"name": "InvalidMarketAccount",
 			"msg": "InvalidMarketAccount"
 		},
-		"UnableToLoadMarketAccount": {
+		"UnableToLoadPerpMarketAccount": {
 			"code": 6080,
-			"name": "UnableToLoadMarketAccount",
+			"name": "UnableToLoadPerpMarketAccount",
 			"msg": "UnableToLoadMarketAccount"
 		},
 		"MarketWrongMutability": {
@@ -457,11 +423,7 @@
 		"NoSpotPositionAvailable": {
 			"code": 6084,
 			"name": "NoSpotPositionAvailable",
-			"msg": "NoSpotPositionAvailable",
-			"toast": {
-				"message": "No Spot Positions Available",
-				"description": "You can hold up to 7 non-USDC spot positions plus 1 USDC position (reserved for perp PnL). Try fully withdrawing an asset or closing an open borrow to free up a position slot."
-			}
+			"msg": "NoSpotPositionAvailable"
 		},
 		"InvalidSpotMarketInitialization": {
 			"code": 6085,
@@ -508,10 +470,10 @@
 			"name": "UserMustSettleTheirOwnPositiveUnsettledPNL",
 			"msg": "UserMustSettleTheirOwnPositiveUnsettledPNL"
 		},
-		"CantUpdatePoolBalanceType": {
+		"CantUpdateSpotBalanceType": {
 			"code": 6094,
-			"name": "CantUpdatePoolBalanceType",
-			"msg": "CantUpdatePoolBalanceType"
+			"name": "CantUpdateSpotBalanceType",
+			"msg": "CantUpdateSpotBalanceType"
 		},
 		"InsufficientCollateralForSettlingPNL": {
 			"code": 6095,
@@ -576,34 +538,22 @@
 		"MakerOrderMustBePostOnly": {
 			"code": 6107,
 			"name": "MakerOrderMustBePostOnly",
-			"msg": "MakerOrderMustBePostOnly",
-			"toast": {
-				"message": "Maker Order Must Be Post Only"
-			}
+			"msg": "MakerOrderMustBePostOnly"
 		},
 		"CantMatchTwoPostOnlys": {
 			"code": 6108,
 			"name": "CantMatchTwoPostOnlys",
-			"msg": "CantMatchTwoPostOnlys",
-			"toast": {
-				"message": "Cannot match Post Only with Post Only"
-			}
+			"msg": "CantMatchTwoPostOnlys"
 		},
 		"OrderBreachesOraclePriceLimits": {
 			"code": 6109,
 			"name": "OrderBreachesOraclePriceLimits",
-			"msg": "OrderBreachesOraclePriceLimits",
-			"toast": {
-				"message": "Order Price Breaches Oracle Price Limits"
-			}
+			"msg": "OrderBreachesOraclePriceLimits"
 		},
 		"OrderMustBeTriggeredFirst": {
 			"code": 6110,
 			"name": "OrderMustBeTriggeredFirst",
-			"msg": "OrderMustBeTriggeredFirst",
-			"toast": {
-				"message": "Order Price Breaches Oracle Price Limits"
-			}
+			"msg": "OrderMustBeTriggeredFirst"
 		},
 		"OrderNotTriggerable": {
 			"code": 6111,
@@ -678,11 +628,7 @@
 		"UserBankrupt": {
 			"code": 6125,
 			"name": "UserBankrupt",
-			"msg": "UserBankrupt",
-			"toast": {
-				"message": "Bankrupt",
-				"description": "Couldn't complete action because the user is currently bankrupt"
-			}
+			"msg": "UserBankrupt"
 		},
 		"UserNotBankrupt": {
 			"code": 6126,
@@ -697,11 +643,7 @@
 		"DailyWithdrawLimit": {
 			"code": 6128,
 			"name": "DailyWithdrawLimit",
-			"msg": "DailyWithdrawLimit",
-			"toast": {
-				"message": "Daily withdrawal limit exceeded",
-				"description": "guard rails around large borrows/withdraws for large accounts are designed to protect the protocol"
-			}
+			"msg": "DailyWithdrawLimit"
 		},
 		"DefaultError": {
 			"code": 6129,
@@ -768,15 +710,15 @@
 			"name": "FailedSerumCPI",
 			"msg": "FailedSerumCPI"
 		},
-		"FailedToFillOnSerum": {
+		"FailedToFillOnExternalMarket": {
 			"code": 6142,
-			"name": "FailedToFillOnSerum",
-			"msg": "FailedToFillOnSerum"
+			"name": "FailedToFillOnExternalMarket",
+			"msg": "FailedToFillOnExternalMarket"
 		},
-		"InvalidSerumFulfillmentConfig": {
+		"InvalidFulfillmentConfig": {
 			"code": 6143,
-			"name": "InvalidSerumFulfillmentConfig",
-			"msg": "InvalidSerumFulfillmentConfig"
+			"name": "InvalidFulfillmentConfig",
+			"msg": "InvalidFulfillmentConfig"
 		},
 		"InvalidFeeStructure": {
 			"code": 6144,
@@ -793,10 +735,30 @@
 			"name": "MarketActionPaused",
 			"msg": "the Market has paused this action"
 		},
-		"AssetTierViolation": {
-			"code": 6133,
-			"name": "AssetTierViolation",
-			"msg": "Action violates the asset tier rules"
+		"MarketPlaceOrderPaused": {
+			"code": 6147,
+			"name": "MarketPlaceOrderPaused",
+			"msg": "the Market status doesnt allow placing orders"
+		},
+		"MarketFillOrderPaused": {
+			"code": 6148,
+			"name": "MarketFillOrderPaused",
+			"msg": "the Market status doesnt allow filling orders"
+		},
+		"MarketWithdrawPaused": {
+			"code": 6149,
+			"name": "MarketWithdrawPaused",
+			"msg": "the Market status doesnt allow withdraws"
+		},
+		"ProtectedAssetTierViolation": {
+			"code": 6150,
+			"name": "ProtectedAssetTierViolation",
+			"msg": "Action violates the Protected Asset Tier rules"
+		},
+		"IsolatedAssetTierViolation": {
+			"code": 6151,
+			"name": "IsolatedAssetTierViolation",
+			"msg": "Action violates the Isolated Asset Tier rules"
 		},
 		"UserCantBeDeleted": {
 			"code": 6152,
@@ -811,11 +773,7 @@
 		"MaxOpenInterest": {
 			"code": 6154,
 			"name": "MaxOpenInterest",
-			"msg": "Max Open Interest",
-			"toast": {
-				"message": "Max Open Interest",
-				"description": "This Market has hit max open interest in this direction. You can still reduce positions normally."
-			}
+			"msg": "Max Open Interest"
 		},
 		"CantResolvePerpBankruptcy": {
 			"code": 6155,
@@ -830,151 +788,12 @@
 		"MarginTradingDisabled": {
 			"code": 6157,
 			"name": "MarginTradingDisabled",
-			"msg": "Margin Trading Disabled",
-			"toast": {
-				"message": "Margin Trading Disabled",
-				"description": ""
-			}
-		},
-		"InvalidOrderMaxTs": {
-			"code": 6043,
-			"name": "InvalidOrderMaxTs",
-			"msg": "InvalidOrderMaxTs"
-		},
-		"InvalidOrderMarketType": {
-			"code": 6044,
-			"name": "InvalidOrderMarketType",
-			"msg": "InvalidOrderMarketType"
-		},
-		"InvalidOrderForInitialMarginReq": {
-			"code": 6045,
-			"name": "InvalidOrderForInitialMarginReq",
-			"msg": "InvalidOrderForInitialMarginReq"
-		},
-		"InvalidOrderNotRiskReducing": {
-			"code": 6046,
-			"name": "InvalidOrderNotRiskReducing",
-			"msg": "InvalidOrderNotRiskReducing",
-			"toast": {
-				"message": "Order is not Risk Reducing",
-				"description": ""
-			}
-		},
-		"InvalidOrderSizeTooSmall": {
-			"code": 6047,
-			"name": "InvalidOrderSizeTooSmall",
-			"msg": "InvalidOrderSizeTooSmall",
-			"toast": {
-				"message": "Order Size is Below Min Order Size",
-				"description": ""
-			}
-		},
-		"InvalidOrderNotStepSizeMultiple": {
-			"code": 6048,
-			"name": "InvalidOrderNotStepSizeMultiple",
-			"msg": "InvalidOrderNotStepSizeMultiple",
-			"toast": {
-				"message": "Order Size is not Multiple of Order Step Size",
-				"description": ""
-			}
-		},
-		"InvalidOrderBaseQuoteAsset": {
-			"code": 6049,
-			"name": "InvalidOrderBaseQuoteAsset",
-			"msg": "InvalidOrderBaseQuoteAsset"
-		},
-		"InvalidOrderIOC": {
-			"code": 6050,
-			"name": "InvalidOrderIOC",
-			"msg": "InvalidOrderIOC"
-		},
-		"InvalidOrderPostOnly": {
-			"code": 6051,
-			"name": "InvalidOrderPostOnly",
-			"msg": "InvalidOrderPostOnly",
-			"toast": {
-				"message": "Order not valid Post-Only",
-				"description": ""
-			}
-		},
-		"InvalidOrderIOCPostOnly": {
-			"code": 6052,
-			"name": "InvalidOrderIOCPostOnly",
-			"msg": "InvalidOrderIOCPostOnly"
-		},
-		"InvalidOrderTrigger": {
-			"code": 6053,
-			"name": "InvalidOrderTrigger",
-			"msg": "InvalidOrderTrigger"
-		},
-		"InvalidOrderAuction": {
-			"code": 6054,
-			"name": "InvalidOrderAuction",
-			"msg": "InvalidOrderAuction"
-		},
-		"InvalidOrderOracleOffset": {
-			"code": 6055,
-			"name": "InvalidOrderOracleOffset",
-			"msg": "InvalidOrderOracleOffset",
-			"toast": {
-				"message": "Order not valid Oracle Offset",
-				"description": ""
-			}
-		},
-		"InvalidOrderMinOrderSize": {
-			"code": 6056,
-			"name": "InvalidOrderMinOrderSize",
-			"msg": "InvalidOrderMinOrderSize",
-			"toast": {
-				"message": "Order size is below minimum order size.",
-				"description": ""
-			}
-		},
-		"MarketPlaceOrderPaused": {
-			"code": 6147,
-			"name": "MarketPlaceOrderPaused",
-			"msg": "the Market status doesnt allow placing orders",
-			"toast": {
-				"message": "Market Place Order Paused",
-				"description": "the Market status doesnt allow placing orders"
-			}
-		},
-		"MarketFillOrderPaused": {
-			"code": 6148,
-			"name": "MarketFillOrderPaused",
-			"msg": "the Market status doesnt allow filling orders",
-			"toast": {
-				"message": "Market Fill Order Paused",
-				"description": "the Market status doesnt allow filling orders"
-			}
-		},
-		"MarketWithdrawPaused": {
-			"code": 6149,
-			"name": "MarketWithdrawPaused",
-			"msg": "the Market status doesnt allow withdraws",
-			"toast": {
-				"message": "Market Withdraw Paused",
-				"description": "the Market status doesnt allow withdraws. please try again later."
-			}
-		},
-		"ProtectedAssetTierViolation": {
-			"code": 6150,
-			"name": "ProtectedAssetTierViolation",
-			"msg": "Action violates the Protected Asset Tier rules"
-		},
-		"IsolatedAssetTierViolation": {
-			"code": 6151,
-			"name": "IsolatedAssetTierViolation",
-			"msg": "Action violates the Isolated Asset Tier rules"
+			"msg": "Margin Trading Disabled"
 		},
 		"InvalidMarketStatusToSettlePnl": {
 			"code": 6158,
 			"name": "InvalidMarketStatusToSettlePnl",
-			"msg": "Invalid Market Status to Settle Perp Pnl",
-			"toast": {
-				"message": "Market Status Settle Pnl Paused",
-				"description": "the Market status doesnt allow pnl settlement. please try again later."
-			}
+			"msg": "Invalid Market Status to Settle Perp Pnl"
 		},
 		"PerpMarketNotInSettlement": {
 			"code": 6159,
@@ -1246,25 +1065,10 @@
 			"name": "SpotOrdersDisabled",
 			"msg": "SpotOrdersDisabled"
 		},
-		"MarketDelisted": {
-			"code": 6007,
-			"name": "MarketDelisted",
-			"msg": "Market Delisted"
-		},
 		"MarketBeingInitialized": {
 			"code": 6213,
 			"name": "MarketBeingInitialized",
 			"msg": "Market Being Initialized"
-		},
-		"PerpMarketNotFound": {
-			"code": 6078,
-			"name": "PerpMarketNotFound",
-			"msg": "PerpMarketNotFound"
-		},
-		"UnableToLoadPerpMarketAccount": {
-			"code": 6080,
-			"name": "UnableToLoadPerpMarketAccount",
-			"msg": "UnableToLoadMarketAccount"
 		},
 		"InvalidUserSubAccountId": {
 			"code": 6214,
@@ -1304,7 +1108,7 @@
 		"SpotFulfillmentConfigDisabled": {
 			"code": 6221,
 			"name": "SpotFulfillmentConfigDisabled",
-			"msg": "Spot Fulfullment Config Disabled"
+			"msg": "Spot Fulfillment Config Disabled"
 		},
 		"InvalidMaker": {
 			"code": 6222,
@@ -1324,20 +1128,12 @@
 		"InvalidOracleForSettlePnl": {
 			"code": 6225,
 			"name": "InvalidOracleForSettlePnl",
-			"msg": "InvalidOracleForSettlePnl",
-			"toast": {
-				"message": "P&L couldn’t be settled",
-				"description": "The Oracle data is too volatile or stale. Please try again in a few minutes."
-			}
+			"msg": "InvalidOracleForSettlePnl"
 		},
 		"MarginOrdersOpen": {
 			"code": 6226,
 			"name": "MarginOrdersOpen",
-			"msg": "MarginOrdersOpen",
-			"toast": {
-				"message": "Can't disable margin trading",
-				"description": "You have orders open that would lead to a borrow being opened."
-			}
+			"msg": "MarginOrdersOpen"
 		},
 		"TierViolationLiquidatingPerpPnl": {
 			"code": 6227,
@@ -1414,16 +1210,6 @@
 			"name": "InvalidSpotFulfillmentParams",
 			"msg": "Invalid Spot Fulfillment Params"
 		},
-		"FailedToFillOnExternalMarket": {
-			"code": 6142,
-			"name": "FailedToFillOnExternalMarket",
-			"msg": "FailedToFillOnExternalMarket"
-		},
-		"InvalidFulfillmentConfig": {
-			"code": 6143,
-			"name": "InvalidFulfillmentConfig",
-			"msg": "InvalidFulfillmentConfig"
-		},
 		"FailedToGetMint": {
 			"code": 6242,
 			"name": "FailedToGetMint",
@@ -1497,12 +1283,7 @@
 		"CantPayUserInitFee": {
 			"code": 6256,
 			"name": "CantPayUserInitFee",
-			"msg": "CantPayUserInitFee",
-			"toast": {
-				"message": "Not enough SOL",
-				"description": "The transaction failed because your wallet did not have enough SOL to cover the user initialization fee. You can learn more about account creation fees in the Drift Docs.",
-				"url": "https://docs.drift.trade/getting-started/managing-subaccount"
-			}
+			"msg": "CantPayUserInitFee"
 		},
 		"CantReclaimRent": {
 			"code": 6257,
@@ -1523,6 +1304,476 @@
 			"code": 6260,
 			"name": "PnlPoolCantSettleUser",
 			"msg": "PnlPoolCantSettleUser"
+		},
+		"OracleNonPositive": {
+			"code": 6261,
+			"name": "OracleNonPositive",
+			"msg": "OracleInvalid"
+		},
+		"OracleTooVolatile": {
+			"code": 6262,
+			"name": "OracleTooVolatile",
+			"msg": "OracleTooVolatile"
+		},
+		"OracleTooUncertain": {
+			"code": 6263,
+			"name": "OracleTooUncertain",
+			"msg": "OracleTooUncertain"
+		},
+		"OracleStaleForMargin": {
+			"code": 6264,
+			"name": "OracleStaleForMargin",
+			"msg": "OracleStaleForMargin"
+		},
+		"OracleInsufficientDataPoints": {
+			"code": 6265,
+			"name": "OracleInsufficientDataPoints",
+			"msg": "OracleInsufficientDataPoints"
+		},
+		"OracleStaleForAMM": {
+			"code": 6266,
+			"name": "OracleStaleForAMM",
+			"msg": "OracleStaleForAMM"
+		},
+		"UnableToParsePullOracleMessage": {
+			"code": 6267,
+			"name": "UnableToParsePullOracleMessage",
+			"msg": "Unable to parse pull oracle message"
+		},
+		"MaxBorrows": {
+			"code": 6268,
+			"name": "MaxBorrows",
+			"msg": "Can not borow more than max borrows"
+		},
+		"OracleUpdatesNotMonotonic": {
+			"code": 6269,
+			"name": "OracleUpdatesNotMonotonic",
+			"msg": "Updates must be monotonically increasing"
+		},
+		"OraclePriceFeedMessageMismatch": {
+			"code": 6270,
+			"name": "OraclePriceFeedMessageMismatch",
+			"msg": "Trying to update price feed with the wrong feed id"
+		},
+		"OracleUnsupportedMessageType": {
+			"code": 6271,
+			"name": "OracleUnsupportedMessageType",
+			"msg": "The message in the update must be a PriceFeedMessage"
+		},
+		"OracleDeserializeMessageFailed": {
+			"code": 6272,
+			"name": "OracleDeserializeMessageFailed",
+			"msg": "Could not deserialize the message in the update"
+		},
+		"OracleWrongGuardianSetOwner": {
+			"code": 6273,
+			"name": "OracleWrongGuardianSetOwner",
+			"msg": "Wrong guardian set owner in update price atomic"
+		},
+		"OracleWrongWriteAuthority": {
+			"code": 6274,
+			"name": "OracleWrongWriteAuthority",
+			"msg": "Oracle post update atomic price feed account must be velocity program"
+		},
+		"OracleWrongVaaOwner": {
+			"code": 6275,
+			"name": "OracleWrongVaaOwner",
+			"msg": "Oracle vaa owner must be wormhole program"
+		},
+		"OracleTooManyPriceAccountUpdates": {
+			"code": 6276,
+			"name": "OracleTooManyPriceAccountUpdates",
+			"msg": "Multi updates must have 2 or fewer accounts passed in remaining accounts"
+		},
+		"OracleMismatchedVaaAndPriceUpdates": {
+			"code": 6277,
+			"name": "OracleMismatchedVaaAndPriceUpdates",
+			"msg": "Don't have the same remaining accounts number and pyth updates left"
+		},
+		"OracleBadRemainingAccountPublicKey": {
+			"code": 6278,
+			"name": "OracleBadRemainingAccountPublicKey",
+			"msg": "Remaining account passed does not match oracle update derived pda"
+		},
+		"FailedOpenbookV2CPI": {
+			"code": 6279,
+			"name": "FailedOpenbookV2CPI",
+			"msg": "FailedOpenbookV2CPI"
+		},
+		"InvalidOpenbookV2Program": {
+			"code": 6280,
+			"name": "InvalidOpenbookV2Program",
+			"msg": "InvalidOpenbookV2Program"
+		},
+		"InvalidOpenbookV2Market": {
+			"code": 6281,
+			"name": "InvalidOpenbookV2Market",
+			"msg": "InvalidOpenbookV2Market"
+		},
+		"NonZeroTransferFee": {
+			"code": 6282,
+			"name": "NonZeroTransferFee",
+			"msg": "Non zero transfer fee"
+		},
+		"LiquidationOrderFailedToFill": {
+			"code": 6283,
+			"name": "LiquidationOrderFailedToFill",
+			"msg": "Liquidation order failed to fill"
+		},
+		"DepreciatedPredictionMarketOrder": {
+			"code": 6284,
+			"name": "DepreciatedPredictionMarketOrder",
+			"msg": "Deprecated"
+		},
+		"InvalidVerificationIxIndex": {
+			"code": 6285,
+			"name": "InvalidVerificationIxIndex",
+			"msg": "Ed25519 Ix must be before place and make SignedMsg order ix"
+		},
+		"SigVerificationFailed": {
+			"code": 6286,
+			"name": "SigVerificationFailed",
+			"msg": "SignedMsg message verificaiton failed"
+		},
+		"MismatchedSignedMsgOrderParamsMarketIndex": {
+			"code": 6287,
+			"name": "MismatchedSignedMsgOrderParamsMarketIndex",
+			"msg": "Market index mismatched b/w taker and maker SignedMsg order params"
+		},
+		"InvalidSignedMsgOrderParam": {
+			"code": 6288,
+			"name": "InvalidSignedMsgOrderParam",
+			"msg": "Invalid SignedMsg order param"
+		},
+		"PlaceAndTakeOrderSuccessConditionFailed": {
+			"code": 6289,
+			"name": "PlaceAndTakeOrderSuccessConditionFailed",
+			"msg": "Place and take order success condition failed"
+		},
+		"DeprecatedHighLeverageModeConfig": {
+			"code": 6290,
+			"name": "DeprecatedHighLeverageModeConfig",
+			"msg": "Deprecated"
+		},
+		"InvalidRFQUserAccount": {
+			"code": 6291,
+			"name": "InvalidRFQUserAccount",
+			"msg": "Invalid RFQ User Account"
+		},
+		"RFQUserAccountWrongMutability": {
+			"code": 6292,
+			"name": "RFQUserAccountWrongMutability",
+			"msg": "RFQUserAccount should be mutable"
+		},
+		"RFQUserAccountFull": {
+			"code": 6293,
+			"name": "RFQUserAccountFull",
+			"msg": "RFQUserAccount has too many active RFQs"
+		},
+		"RFQOrderNotFilled": {
+			"code": 6294,
+			"name": "RFQOrderNotFilled",
+			"msg": "RFQ order not filled as expected"
+		},
+		"InvalidRFQOrder": {
+			"code": 6295,
+			"name": "InvalidRFQOrder",
+			"msg": "RFQ orders must be jit makers"
+		},
+		"InvalidRFQMatch": {
+			"code": 6296,
+			"name": "InvalidRFQMatch",
+			"msg": "RFQ matches must be valid"
+		},
+		"InvalidSignedMsgUserAccount": {
+			"code": 6297,
+			"name": "InvalidSignedMsgUserAccount",
+			"msg": "Invalid SignedMsg user account"
+		},
+		"SignedMsgUserAccountWrongMutability": {
+			"code": 6298,
+			"name": "SignedMsgUserAccountWrongMutability",
+			"msg": "SignedMsg account wrong mutability"
+		},
+		"SignedMsgUserOrdersAccountFull": {
+			"code": 6299,
+			"name": "SignedMsgUserOrdersAccountFull",
+			"msg": "SignedMsgUserAccount has too many active orders"
+		},
+		"SignedMsgOrderDoesNotExist": {
+			"code": 6300,
+			"name": "SignedMsgOrderDoesNotExist",
+			"msg": "Order with SignedMsg uuid does not exist"
+		},
+		"InvalidSignedMsgOrderId": {
+			"code": 6301,
+			"name": "InvalidSignedMsgOrderId",
+			"msg": "SignedMsg order id cannot be 0s"
+		},
+		"InvalidPoolId": {
+			"code": 6302,
+			"name": "InvalidPoolId",
+			"msg": "Invalid pool id"
+		},
+		"InvalidProtectedMakerModeConfig": {
+			"code": 6303,
+			"name": "InvalidProtectedMakerModeConfig",
+			"msg": "Invalid Protected Maker Mode Config"
+		},
+		"InvalidPythLazerStorageOwner": {
+			"code": 6304,
+			"name": "InvalidPythLazerStorageOwner",
+			"msg": "Invalid pyth lazer storage owner"
+		},
+		"UnverifiedPythLazerMessage": {
+			"code": 6305,
+			"name": "UnverifiedPythLazerMessage",
+			"msg": "Verification of pyth lazer message failed"
+		},
+		"InvalidPythLazerMessage": {
+			"code": 6306,
+			"name": "InvalidPythLazerMessage",
+			"msg": "Invalid pyth lazer message"
+		},
+		"PythLazerMessagePriceFeedMismatch": {
+			"code": 6307,
+			"name": "PythLazerMessagePriceFeedMismatch",
+			"msg": "Pyth lazer message does not correspond to correct fed id"
+		},
+		"InvalidLiquidateSpotWithSwap": {
+			"code": 6308,
+			"name": "InvalidLiquidateSpotWithSwap",
+			"msg": "InvalidLiquidateSpotWithSwap"
+		},
+		"SignedMsgUserContextUserMismatch": {
+			"code": 6309,
+			"name": "SignedMsgUserContextUserMismatch",
+			"msg": "User in SignedMsg message does not match user in ix context"
+		},
+		"Deprecated1": {
+			"code": 6310,
+			"name": "Deprecated1",
+			"msg": "Deprecated"
+		},
+		"Deprecated2": {
+			"code": 6311,
+			"name": "Deprecated2",
+			"msg": "Deprecated"
+		},
+		"InvalidTransferPerpPosition": {
+			"code": 6312,
+			"name": "InvalidTransferPerpPosition",
+			"msg": "Invalid Transfer Perp Position"
+		},
+		"InvalidSignedMsgUserOrdersResize": {
+			"code": 6313,
+			"name": "InvalidSignedMsgUserOrdersResize",
+			"msg": "Invalid SignedMsgUserOrders resize"
+		},
+		"DeprecatedCouldNotDeserializeHighLeverageModeConfig": {
+			"code": 6314,
+			"name": "DeprecatedCouldNotDeserializeHighLeverageModeConfig",
+			"msg": "Deprecated"
+		},
+		"InvalidIfRebalanceConfig": {
+			"code": 6315,
+			"name": "InvalidIfRebalanceConfig",
+			"msg": "Invalid If Rebalance Config"
+		},
+		"InvalidIfRebalanceSwap": {
+			"code": 6316,
+			"name": "InvalidIfRebalanceSwap",
+			"msg": "Invalid If Rebalance Swap"
+		},
+		"InvalidRevenueShareResize": {
+			"code": 6317,
+			"name": "InvalidRevenueShareResize",
+			"msg": "Invalid RevenueShare resize"
+		},
+		"BuilderRevoked": {
+			"code": 6318,
+			"name": "BuilderRevoked",
+			"msg": "Builder has been revoked"
+		},
+		"InvalidBuilderFee": {
+			"code": 6319,
+			"name": "InvalidBuilderFee",
+			"msg": "Builder fee is greater than max fee bps"
+		},
+		"RevenueShareEscrowAuthorityMismatch": {
+			"code": 6320,
+			"name": "RevenueShareEscrowAuthorityMismatch",
+			"msg": "RevenueShareEscrow authority mismatch"
+		},
+		"RevenueShareEscrowOrdersAccountFull": {
+			"code": 6321,
+			"name": "RevenueShareEscrowOrdersAccountFull",
+			"msg": "RevenueShareEscrow has too many active orders"
+		},
+		"InvalidRevenueShareAccount": {
+			"code": 6322,
+			"name": "InvalidRevenueShareAccount",
+			"msg": "Invalid RevenueShareAccount"
+		},
+		"CannotRevokeBuilderWithOpenOrders": {
+			"code": 6323,
+			"name": "CannotRevokeBuilderWithOpenOrders",
+			"msg": "Cannot revoke builder with open orders"
+		},
+		"UnableToLoadRevenueShareAccount": {
+			"code": 6324,
+			"name": "UnableToLoadRevenueShareAccount",
+			"msg": "Unable to load builder account"
+		},
+		"InvalidConstituent": {
+			"code": 6325,
+			"name": "InvalidConstituent",
+			"msg": "Invalid Constituent"
+		},
+		"InvalidAmmConstituentMappingArgument": {
+			"code": 6326,
+			"name": "InvalidAmmConstituentMappingArgument",
+			"msg": "Invalid Amm Constituent Mapping argument"
+		},
+		"ConstituentNotFound": {
+			"code": 6327,
+			"name": "ConstituentNotFound",
+			"msg": "Constituent not found"
+		},
+		"ConstituentCouldNotLoad": {
+			"code": 6328,
+			"name": "ConstituentCouldNotLoad",
+			"msg": "Constituent could not load"
+		},
+		"ConstituentWrongMutability": {
+			"code": 6329,
+			"name": "ConstituentWrongMutability",
+			"msg": "Constituent wrong mutability"
+		},
+		"WrongNumberOfConstituents": {
+			"code": 6330,
+			"name": "WrongNumberOfConstituents",
+			"msg": "Wrong number of constituents passed to instruction"
+		},
+		"InsufficientConstituentTokenBalance": {
+			"code": 6331,
+			"name": "InsufficientConstituentTokenBalance",
+			"msg": "Insufficient constituent token balance"
+		},
+		"AMMCacheStale": {
+			"code": 6332,
+			"name": "AMMCacheStale",
+			"msg": "Amm Cache data too stale"
+		},
+		"LpPoolAumDelayed": {
+			"code": 6333,
+			"name": "LpPoolAumDelayed",
+			"msg": "LP Pool AUM not updated recently"
+		},
+		"ConstituentOracleStale": {
+			"code": 6334,
+			"name": "ConstituentOracleStale",
+			"msg": "Constituent oracle is stale"
+		},
+		"LpInvariantFailed": {
+			"code": 6335,
+			"name": "LpInvariantFailed",
+			"msg": "LP Invariant failed"
+		},
+		"InvalidConstituentDerivativeWeights": {
+			"code": 6336,
+			"name": "InvalidConstituentDerivativeWeights",
+			"msg": "Invalid constituent derivative weights"
+		},
+		"MaxDlpAumBreached": {
+			"code": 6337,
+			"name": "MaxDlpAumBreached",
+			"msg": "Max DLP AUM Breached"
+		},
+		"SettleLpPoolDisabled": {
+			"code": 6338,
+			"name": "SettleLpPoolDisabled",
+			"msg": "Settle Lp Pool Disabled"
+		},
+		"MintRedeemLpPoolDisabled": {
+			"code": 6339,
+			"name": "MintRedeemLpPoolDisabled",
+			"msg": "Mint/Redeem Lp Pool Disabled"
+		},
+		"LpPoolSettleInvariantBreached": {
+			"code": 6340,
+			"name": "LpPoolSettleInvariantBreached",
+			"msg": "Settlement amount exceeded"
+		},
+		"InvalidConstituentOperation": {
+			"code": 6341,
+			"name": "InvalidConstituentOperation",
+			"msg": "Invalid constituent operation"
+		},
+		"Unauthorized": {
+			"code": 6342,
+			"name": "Unauthorized",
+			"msg": "Unauthorized for operation"
+		},
+		"InvalidLpPoolId": {
+			"code": 6343,
+			"name": "InvalidLpPoolId",
+			"msg": "Invalid Lp Pool Id for Operation"
+		},
+		"MarketIndexNotFoundAmmCache": {
+			"code": 6344,
+			"name": "MarketIndexNotFoundAmmCache",
+			"msg": "MarketIndexNotFoundAmmCache"
+		},
+		"InvalidIsolatedPerpMarket": {
+			"code": 6345,
+			"name": "InvalidIsolatedPerpMarket",
+			"msg": "Invalid Isolated Perp Market"
+		},
+		"InvalidOrderScaleOrderCount": {
+			"code": 6346,
+			"name": "InvalidOrderScaleOrderCount",
+			"msg": "Invalid scale order count - must be between 2 and 10"
+		},
+		"InvalidOrderScalePriceRange": {
+			"code": 6347,
+			"name": "InvalidOrderScalePriceRange",
+			"msg": "Invalid scale order price range"
+		},
+		"InvalidPerpMarketConfig": {
+			"code": 6348,
+			"name": "InvalidPerpMarketConfig",
+			"msg": "Invalid perp market config"
+		},
+		"InvalidInsuranceFundWithdrawalRecipient": {
+			"code": 6349,
+			"name": "InvalidInsuranceFundWithdrawalRecipient",
+			"msg": "Insurance fund withdrawal recipient must be the designated treasury address"
+		},
+		"SpotDlobTradingDisabled": {
+			"code": 6350,
+			"name": "SpotDlobTradingDisabled",
+			"msg": "Spot DLOB trading is disabled"
+		},
+		"InvalidAdminTier": {
+			"code": 6351,
+			"name": "InvalidAdminTier",
+			"msg": "Signer is not authorized for this admin tier"
+		},
+		"WithdrawGuardThresholdNotionalTooLarge": {
+			"code": 6352,
+			"name": "WithdrawGuardThresholdNotionalTooLarge",
+			"msg": "Withdraw guard threshold notional exceeds max"
+		},
+		"InvalidProtocolFeeRecipient": {
+			"code": 6353,
+			"name": "InvalidProtocolFeeRecipient",
+			"msg": "Recipient must be the configured protocol fee recipient"
+		},
+		"InsufficientProtocolFees": {
+			"code": 6354,
+			"name": "InsufficientProtocolFees",
+			"msg": "Insufficient protocol fees available to withdraw"
 		}
 	},
 	"errorCodesMap": {
@@ -1620,7 +1871,7 @@
 		"6091": "SpotMarketInterestNotUpToDate",
 		"6092": "SpotMarketInsufficientDeposits",
 		"6093": "UserMustSettleTheirOwnPositiveUnsettledPNL",
-		"6094": "CantUpdatePoolBalanceType",
+		"6094": "CantUpdateSpotBalanceType",
 		"6095": "InsufficientCollateralForSettlingPNL",
 		"6096": "AMMNotUpdatedInSameSlot",
 		"6097": "AuctionNotComplete",
@@ -1786,6 +2037,100 @@
 		"6257": "CantReclaimRent",
 		"6258": "InsuranceFundOperationPaused",
 		"6259": "NoUnsettledPnl",
-		"6260": "PnlPoolCantSettleUser"
+		"6260": "PnlPoolCantSettleUser",
+		"6261": "OracleNonPositive",
+		"6262": "OracleTooVolatile",
+		"6263": "OracleTooUncertain",
+		"6264": "OracleStaleForMargin",
+		"6265": "OracleInsufficientDataPoints",
+		"6266": "OracleStaleForAMM",
+		"6267": "UnableToParsePullOracleMessage",
+		"6268": "MaxBorrows",
+		"6269": "OracleUpdatesNotMonotonic",
+		"6270": "OraclePriceFeedMessageMismatch",
+		"6271": "OracleUnsupportedMessageType",
+		"6272": "OracleDeserializeMessageFailed",
+		"6273": "OracleWrongGuardianSetOwner",
+		"6274": "OracleWrongWriteAuthority",
+		"6275": "OracleWrongVaaOwner",
+		"6276": "OracleTooManyPriceAccountUpdates",
+		"6277": "OracleMismatchedVaaAndPriceUpdates",
+		"6278": "OracleBadRemainingAccountPublicKey",
+		"6279": "FailedOpenbookV2CPI",
+		"6280": "InvalidOpenbookV2Program",
+		"6281": "InvalidOpenbookV2Market",
+		"6282": "NonZeroTransferFee",
+		"6283": "LiquidationOrderFailedToFill",
+		"6284": "DepreciatedPredictionMarketOrder",
+		"6285": "InvalidVerificationIxIndex",
+		"6286": "SigVerificationFailed",
+		"6287": "MismatchedSignedMsgOrderParamsMarketIndex",
+		"6288": "InvalidSignedMsgOrderParam",
+		"6289": "PlaceAndTakeOrderSuccessConditionFailed",
+		"6290": "DeprecatedHighLeverageModeConfig",
+		"6291": "InvalidRFQUserAccount",
+		"6292": "RFQUserAccountWrongMutability",
+		"6293": "RFQUserAccountFull",
+		"6294": "RFQOrderNotFilled",
+		"6295": "InvalidRFQOrder",
+		"6296": "InvalidRFQMatch",
+		"6297": "InvalidSignedMsgUserAccount",
+		"6298": "SignedMsgUserAccountWrongMutability",
+		"6299": "SignedMsgUserOrdersAccountFull",
+		"6300": "SignedMsgOrderDoesNotExist",
+		"6301": "InvalidSignedMsgOrderId",
+		"6302": "InvalidPoolId",
+		"6303": "InvalidProtectedMakerModeConfig",
+		"6304": "InvalidPythLazerStorageOwner",
+		"6305": "UnverifiedPythLazerMessage",
+		"6306": "InvalidPythLazerMessage",
+		"6307": "PythLazerMessagePriceFeedMismatch",
+		"6308": "InvalidLiquidateSpotWithSwap",
+		"6309": "SignedMsgUserContextUserMismatch",
+		"6310": "Deprecated1",
+		"6311": "Deprecated2",
+		"6312": "InvalidTransferPerpPosition",
+		"6313": "InvalidSignedMsgUserOrdersResize",
+		"6314": "DeprecatedCouldNotDeserializeHighLeverageModeConfig",
+		"6315": "InvalidIfRebalanceConfig",
+		"6316": "InvalidIfRebalanceSwap",
+		"6317": "InvalidRevenueShareResize",
+		"6318": "BuilderRevoked",
+		"6319": "InvalidBuilderFee",
+		"6320": "RevenueShareEscrowAuthorityMismatch",
+		"6321": "RevenueShareEscrowOrdersAccountFull",
+		"6322": "InvalidRevenueShareAccount",
+		"6323": "CannotRevokeBuilderWithOpenOrders",
+		"6324": "UnableToLoadRevenueShareAccount",
+		"6325": "InvalidConstituent",
+		"6326": "InvalidAmmConstituentMappingArgument",
+		"6327": "ConstituentNotFound",
+		"6328": "ConstituentCouldNotLoad",
+		"6329": "ConstituentWrongMutability",
+		"6330": "WrongNumberOfConstituents",
+		"6331": "InsufficientConstituentTokenBalance",
+		"6332": "AMMCacheStale",
+		"6333": "LpPoolAumDelayed",
+		"6334": "ConstituentOracleStale",
+		"6335": "LpInvariantFailed",
+		"6336": "InvalidConstituentDerivativeWeights",
+		"6337": "MaxDlpAumBreached",
+		"6338": "SettleLpPoolDisabled",
+		"6339": "MintRedeemLpPoolDisabled",
+		"6340": "LpPoolSettleInvariantBreached",
+		"6341": "InvalidConstituentOperation",
+		"6342": "Unauthorized",
+		"6343": "InvalidLpPoolId",
+		"6344": "MarketIndexNotFoundAmmCache",
+		"6345": "InvalidIsolatedPerpMarket",
+		"6346": "InvalidOrderScaleOrderCount",
+		"6347": "InvalidOrderScalePriceRange",
+		"6348": "InvalidPerpMarketConfig",
+		"6349": "InvalidInsuranceFundWithdrawalRecipient",
+		"6350": "SpotDlobTradingDisabled",
+		"6351": "InvalidAdminTier",
+		"6352": "WithdrawGuardThresholdNotionalTooLarge",
+		"6353": "InvalidProtocolFeeRecipient",
+		"6354": "InsufficientProtocolFees"
 	}
 }

--- a/common-ts/src/drift/Velocity/clients/CentralServerVelocity/index.ts
+++ b/common-ts/src/drift/Velocity/clients/CentralServerVelocity/index.ts
@@ -834,7 +834,7 @@ export class CentralServerVelocity {
 	 * Single transaction: close isolated position + optionally withdraw collateral.
 	 * Without placeAndTake that atomically fills the close, the entire transaction may FAIL:
 	 * the withdraw ix runs after the close, and if the close did not fill in this tx,
-	 * the whole tx will fail. Strongly consider placeAndTake: { enable: true, referrerInfo: undefined }
+	 * the whole tx will fail. Strongly consider placeAndTake: { enable: true }
 	 * when closing and withdrawing in the same tx.
 	 */
 	public async getCloseAndWithdrawIsolatedPerpPositionTxn(
@@ -968,7 +968,7 @@ export class CentralServerVelocity {
 	 * Flow: close order, then withdraw from isolated directly to wallet (bundle handles settle if needed).
 	 * Without placeAndTake that atomically fills the close, the entire transaction may FAIL:
 	 * the withdraw runs after the close, and if the close did not fill in this tx, the withdraw may fail depending on withdraw amount.
-	 * Strongly consider placeAndTake: { enable: true, referrerInfo: undefined } when closing and withdrawing.
+	 * Strongly consider placeAndTake: { enable: true } when closing and withdrawing.
 	 */
 	public async getCloseAndWithdrawIsolatedPerpPositionToWalletTxn(
 		params: CentralServerGetCloseAndWithdrawIsolatedPerpPositionToWalletTxnParams

--- a/common-ts/src/drift/Velocity/constants/blockchain.ts
+++ b/common-ts/src/drift/Velocity/constants/blockchain.ts
@@ -27,7 +27,6 @@ export enum PollingCategory {
  * These accounts can be used to estimate priority fees.
  */
 export const HIGH_ACTIVITY_MARKET_ACCOUNTS = [
-	new PublicKey('8BnEgHoWFysVcuFFX7QztDmzuH8r5ZFvyP3sYwn1XTh6'), // sol openbook market
 	new PublicKey('8UJgxaiQx5nTrdDgph5FiahMmzduuLTLf5WmsPegYA6W'), // sol perp
 	new PublicKey('6gMq3mRCKf8aP3ttTyYhuijVZ2LGi14oDsBbkgubfLB3'), // usdc
 ];

--- a/common-ts/src/drift/Velocity/data/PollingDlob.ts
+++ b/common-ts/src/drift/Velocity/data/PollingDlob.ts
@@ -63,11 +63,10 @@ export const POLLING_DEPTHS = {
  * pollingDlob.addInterval('idle', 30, 1);         // Every 30s with depth 1
  *
  * // Add markets to intervals
+ * // Note: only perp markets have an active DLOB order book; spot DLOB trading is disabled.
  * const perpMarket = MarketId.createPerpMarket(0);
- * const spotMarket = MarketId.createSpotMarket(0);
  *
  * pollingDlob.addMarketToInterval('live', perpMarket);
- * pollingDlob.addMarketToInterval('background', spotMarket);
  *
  * // Subscribe to data updates
  * pollingDlob.onData().subscribe(marketData => {

--- a/common-ts/src/drift/base/actions/markets/oracleCrank/constants.ts
+++ b/common-ts/src/drift/base/actions/markets/oracleCrank/constants.ts
@@ -1,5 +1,3 @@
 export const MAX_PYTH_LAZER_CRANKS = 1;
 
-export const MAX_PYTH_PULL_CRANKS = 1;
-
 export const DEFAULT_PRECEDING_IXS_COUNT = 2;

--- a/common-ts/src/drift/base/actions/markets/oracleCrank/oracleSourceHelpers.ts
+++ b/common-ts/src/drift/base/actions/markets/oracleCrank/oracleSourceHelpers.ts
@@ -1,12 +1,6 @@
 import { OracleSource } from '@velocity-exchange/sdk';
 import { ENUM_UTILS } from '../../../../../utils';
 
-export const isPythPull = (oracleSource: OracleSource): boolean =>
-	ENUM_UTILS.match(OracleSource.PYTH_PULL, oracleSource) ||
-	ENUM_UTILS.match(OracleSource.PYTH_1K_PULL, oracleSource) ||
-	ENUM_UTILS.match(OracleSource.PYTH_1M_PULL, oracleSource) ||
-	ENUM_UTILS.match(OracleSource.PYTH_STABLE_COIN_PULL, oracleSource);
-
 export const isPythLazer = (oracleSource: OracleSource): boolean =>
 	ENUM_UTILS.match(OracleSource.PYTH_LAZER, oracleSource) ||
 	ENUM_UTILS.match(OracleSource.PYTH_LAZER_1K, oracleSource) ||

--- a/common-ts/src/drift/base/actions/markets/oracleCrank/types.ts
+++ b/common-ts/src/drift/base/actions/markets/oracleCrank/types.ts
@@ -10,7 +10,7 @@ export type OracleCrankFetchResult = {
 };
 
 export type OracleCrankDataFetcher = (
-	source: 'pythPull' | 'pythLazer',
+	source: 'pythLazer',
 	feedIds: (number | string)[]
 ) => Promise<OracleCrankFetchResult>;
 
@@ -20,7 +20,6 @@ export type GetOracleCrankIxsOptions = {
 	marketConfigs: OracleMarketConfig[];
 	velocityClient: VelocityClient;
 	fetchCrankData: OracleCrankDataFetcher;
-	maxPythPullCranks?: number;
 	maxPythLazerCranks?: number;
 	precedingIxsCount?: number;
 };

--- a/common-ts/src/drift/base/actions/trade/openPerpOrder/dlobServer/index.ts
+++ b/common-ts/src/drift/base/actions/trade/openPerpOrder/dlobServer/index.ts
@@ -10,7 +10,6 @@ import {
 	decodeUser,
 	DefaultOrderParams,
 	BASE_PRECISION,
-	TEN,
 } from '@velocity-exchange/sdk';
 import { ENUM_UTILS } from '../../../../../../utils';
 import {
@@ -74,9 +73,6 @@ export interface BulkL2FetchingQueryParams {
 	marketType: string;
 	depth: number;
 	includeVamm: boolean;
-	includePhoenix: boolean;
-	includeOpenbook: boolean;
-	includeSerum: boolean;
 	includeOracle: boolean;
 	includeIndicative: boolean;
 }
@@ -106,9 +102,6 @@ export function fetchBulkMarketsDlobL2Data(
 			marketType: m.marketId.marketTypeStr,
 			depth: m.depth,
 			includeVamm: m.marketId.isPerp,
-			includePhoenix: m.marketId.isSpot,
-			includeSerum: m.marketId.isSpot,
-			includeOpenbook: m.marketId.isSpot,
 			includeOracle: true,
 			includeIndicative: !excludeIndicativeLiquidity,
 		})),
@@ -124,13 +117,6 @@ export function fetchBulkMarketsDlobL2Data(
 		marketIndex: params.markets.map((market) => market.marketIndex).join(','),
 		depth: params.markets.map((market) => market.depth).join(','),
 		includeVamm: params.markets.map((market) => market.includeVamm).join(','),
-		includePhoenix: params.markets
-			.map((market) => market.includePhoenix)
-			.join(','),
-		includeOpenbook: params.markets
-			.map((market) => market.includeOpenbook)
-			.join(','),
-		includeSerum: params.markets.map((market) => market.includeSerum).join(','),
 		grouping: params.grouping
 			? params.markets.map(() => params.grouping).join(',')
 			: undefined,
@@ -181,24 +167,12 @@ export async function fetchAuctionOrderParams(params: RegularOrderParams) {
 
 const calcBaseFromQuote = (
 	velocityClient: VelocityClient,
-	marketType: MarketType,
 	marketIndex: number,
 	amount: BN
 ) => {
-	const isPerp = ENUM_UTILS.match(marketType, MarketType.PERP);
-
-	const oraclePrice = isPerp
-		? velocityClient.getOracleDataForPerpMarket(marketIndex).price
-		: velocityClient.getOracleDataForSpotMarket(marketIndex).price;
-
-	if (isPerp) {
-		return amount.mul(BASE_PRECISION).div(oraclePrice);
-	} else {
-		const spotMarketAccount = velocityClient.getSpotMarketAccount(marketIndex);
-		invariant(spotMarketAccount, 'Spot market account not found');
-		const precision = TEN.pow(new BN(spotMarketAccount.decimals));
-		return amount.mul(precision).div(oraclePrice);
-	}
+	const oraclePrice =
+		velocityClient.getOracleDataForPerpMarket(marketIndex).price;
+	return amount.mul(BASE_PRECISION).div(oraclePrice);
 };
 
 /**
@@ -218,7 +192,7 @@ export async function fetchAuctionOrderParamsFromDlob({
 	const baseAmount =
 		assetType === 'base'
 			? amount
-			: calcBaseFromQuote(velocityClient, marketType, marketIndex, amount);
+			: calcBaseFromQuote(velocityClient, marketIndex, amount);
 
 	// Build URL parameters for server request
 	const urlParamsObject: Record<string, string> = {
@@ -299,7 +273,7 @@ export async function fetchAuctionOrderParamsFromL2({
 	const baseAmount =
 		assetType === 'base'
 			? amount
-			: calcBaseFromQuote(velocityClient, marketType, marketIndex, amount);
+			: calcBaseFromQuote(velocityClient, marketIndex, amount);
 
 	const l2DataResponse = await fetchBulkMarketsDlobL2Data(dlobServerHttpUrl, [
 		{

--- a/common-ts/src/drift/base/actions/trade/openPerpOrder/openPerpMarketOrder/index.ts
+++ b/common-ts/src/drift/base/actions/trade/openPerpOrder/openPerpMarketOrder/index.ts
@@ -7,6 +7,7 @@ import {
 	MarketType,
 	getUserStatsAccountPublicKey,
 	OrderType,
+	RevenueShareEscrowAccount,
 } from '@velocity-exchange/sdk';
 import {
 	PublicKey,
@@ -82,7 +83,6 @@ export interface OpenPerpMarketOrderBaseParams {
 	mainSignerOverride?: PublicKey;
 	/**
 	 * Optional builder code parameters for revenue sharing.
-	 * Only applicable for Swift orders.
 	 *
 	 * Prerequisites:
 	 * - User must have initialized a RevenueShareEscrow account
@@ -320,6 +320,8 @@ export const createPlaceAndTakePerpMarketOrderIx = async ({
 	optionalAuctionParamsInputs,
 	mainSignerOverride,
 	callbacks,
+	takerEscrow,
+	builderParams,
 }: Omit<
 	OpenPerpMarketOrderBaseParams,
 	'marginMode' | 'isolatedPositionDepositsOverride'
@@ -332,6 +334,7 @@ export const createPlaceAndTakePerpMarketOrderIx = async ({
 	velocityClient: VelocityClient;
 	user: User;
 	auctionDurationPercentage?: number;
+	takerEscrow?: RevenueShareEscrowAccount;
 }) => {
 	const counterPartySide = ENUM_UTILS.match(direction, PositionDirection.LONG)
 		? 'ask'
@@ -371,6 +374,11 @@ export const createPlaceAndTakePerpMarketOrderIx = async ({
 		fetchedOrderParams.auctionEndPrice = price;
 	}
 
+	if (builderParams) {
+		fetchedOrderParams.builderIdx = builderParams.builderIdx;
+		fetchedOrderParams.builderFeeTenthBps = builderParams.builderFeeTenthBps;
+	}
+
 	if (!topMakersResult || topMakersResult.length === 0) {
 		throw new NoTopMakersError('No top makers found', fetchedOrderParams);
 	}
@@ -392,7 +400,8 @@ export const createPlaceAndTakePerpMarketOrderIx = async ({
 		user.getUserAccount().subAccountId,
 		{
 			authority: mainSignerOverride,
-		}
+		},
+		takerEscrow
 	);
 
 	return placeAndTakeIx;
@@ -433,6 +442,7 @@ export const createOpenPerpMarketOrderIxs = async ({
 	marginMode,
 	isolatedPositionDepositsOverride,
 	callbacks,
+	builderParams,
 }: OpenPerpMarketOrderBaseParams): Promise<TransactionInstruction[]> => {
 	if (!amount || amount.isZero()) {
 		throw new Error('Amount must be greater than zero');
@@ -516,9 +526,11 @@ export const createOpenPerpMarketOrderIxs = async ({
 				userOrderId,
 				reduceOnly,
 				auctionDurationPercentage: placeAndTake.auctionDurationPercentage,
+				takerEscrow: placeAndTake.takerEscrow,
 				optionalAuctionParamsInputs,
 				mainSignerOverride,
 				positionMaxLeverage,
+				builderParams,
 			});
 			allIxs.push(placeAndTakeIx);
 		} catch (e) {
@@ -547,6 +559,10 @@ export const createOpenPerpMarketOrderIxs = async ({
 		const orderParams = {
 			...fetchedOrderParams,
 			userOrderId,
+			...(builderParams && {
+				builderIdx: builderParams.builderIdx,
+				builderFeeTenthBps: builderParams.builderFeeTenthBps,
+			}),
 		};
 
 		allOrders.push(orderParams);

--- a/common-ts/src/drift/base/actions/trade/openPerpOrder/openPerpMarketOrder/index.ts
+++ b/common-ts/src/drift/base/actions/trade/openPerpOrder/openPerpMarketOrder/index.ts
@@ -29,9 +29,14 @@ import {
 	OptionalAuctionParamsRequestInputs,
 } from '../dlobServer';
 import { WithTxnParams } from '../../../../types';
-import { TxnOrSwiftResult, IsolatedPositionDepositsOverride } from '../types';
+import {
+	TxnOrSwiftResult,
+	IsolatedPositionDepositsOverride,
+	PlaceAndTakeParams,
+	OptionalTriggerOrderParams,
+	BuilderParams,
+} from '../types';
 import { NoTopMakersError } from '../../../../../Velocity/constants/errors';
-import { PlaceAndTakeParams, OptionalTriggerOrderParams } from '../types';
 import { getPositionMaxLeverageIxIfNeeded } from '../positionMaxLeverage';
 import { AuctionParamsFetchedCallback } from '../../../../../utils/auctionParamsResponseMapper';
 import {
@@ -97,17 +102,7 @@ export interface OpenPerpMarketOrderBaseParams {
 	 * }
 	 * ```
 	 */
-	builderParams?: {
-		/**
-		 * Index of the builder in the user's approved_builders list.
-		 */
-		builderIdx: number;
-		/**
-		 * Fee to charge for this order, in tenths of basis points.
-		 * Must be <= the builder's max_fee_tenth_bps.
-		 */
-		builderFeeTenthBps: number;
-	};
+	builderParams?: BuilderParams;
 	callbacks?: {
 		onAuctionParamsFetched?: AuctionParamsFetchedCallback;
 	};
@@ -374,11 +369,6 @@ export const createPlaceAndTakePerpMarketOrderIx = async ({
 		fetchedOrderParams.auctionEndPrice = price;
 	}
 
-	if (builderParams) {
-		fetchedOrderParams.builderIdx = builderParams.builderIdx;
-		fetchedOrderParams.builderFeeTenthBps = builderParams.builderFeeTenthBps;
-	}
-
 	if (!topMakersResult || topMakersResult.length === 0) {
 		throw new NoTopMakersError('No top makers found', fetchedOrderParams);
 	}
@@ -393,7 +383,7 @@ export const createPlaceAndTakePerpMarketOrderIx = async ({
 	}));
 
 	const placeAndTakeIx = await velocityClient.getPlaceAndTakePerpOrderIx(
-		fetchedOrderParams,
+		{ ...fetchedOrderParams, ...(builderParams ?? {}) },
 		topMakersInfo,
 		undefined,
 		auctionDurationPercentage,
@@ -559,10 +549,7 @@ export const createOpenPerpMarketOrderIxs = async ({
 		const orderParams = {
 			...fetchedOrderParams,
 			userOrderId,
-			...(builderParams && {
-				builderIdx: builderParams.builderIdx,
-				builderFeeTenthBps: builderParams.builderFeeTenthBps,
-			}),
+			...(builderParams ?? {}),
 		};
 
 		allOrders.push(orderParams);

--- a/common-ts/src/drift/base/actions/trade/openPerpOrder/openPerpNonMarketOrder/index.ts
+++ b/common-ts/src/drift/base/actions/trade/openPerpOrder/openPerpNonMarketOrder/index.ts
@@ -75,7 +75,6 @@ export interface OpenPerpNonMarketOrderBaseParams
 	mainSignerOverride?: PublicKey;
 	/**
 	 * Optional builder code parameters for revenue sharing.
-	 * Only applicable for Swift orders for now.
 	 */
 	builderParams?: {
 		builderIdx: number;
@@ -116,10 +115,28 @@ export const createMultipleOpenPerpNonMarketOrderIx = async (params: {
 	 * If provided, will override the main signer for the order. Otherwise, the main signer will be the user's authority.
 	 */
 	mainSignerOverride?: PublicKey;
+	/**
+	 * Optional builder code parameters for revenue sharing, applied to every order in the batch.
+	 */
+	builderParams?: {
+		builderIdx: number;
+		builderFeeTenthBps: number;
+	};
 }): Promise<TransactionInstruction> => {
-	const { velocityClient, orderParamsConfigs, mainSignerOverride } = params;
+	const {
+		velocityClient,
+		orderParamsConfigs,
+		mainSignerOverride,
+		builderParams,
+	} = params;
 
-	const orderParams = orderParamsConfigs.map(buildNonMarketOrderParams);
+	const orderParams = orderParamsConfigs.map((config) => ({
+		...buildNonMarketOrderParams(config),
+		...(builderParams && {
+			builderIdx: builderParams.builderIdx,
+			builderFeeTenthBps: builderParams.builderFeeTenthBps,
+		}),
+	}));
 
 	const placeOrderIx = await velocityClient.getPlaceOrdersIx(
 		orderParams,
@@ -154,6 +171,7 @@ export const createOpenPerpNonMarketOrderIxs = async (
 		marginMode,
 		mainSignerOverride,
 		isolatedPositionDepositsOverride,
+		builderParams,
 	} = params;
 	// Support both new (amount + assetType) and legacy (baseAssetAmount) approaches
 	const finalBaseAssetAmount = resolveBaseAssetAmount({
@@ -279,6 +297,8 @@ export const createOpenPerpNonMarketOrderIxs = async (
 						orderConfig.limitAuction.optionalLimitAuctionParams,
 					auctionDurationPercentage:
 						orderConfig.limitAuction.usePlaceAndTake.auctionDurationPercentage,
+					takerEscrow: orderConfig.limitAuction.usePlaceAndTake.takerEscrow,
+					builderParams,
 				});
 				allIxs.push(placeAndTakeIx);
 				createdPlaceAndTakeIx = true;
@@ -293,7 +313,13 @@ export const createOpenPerpNonMarketOrderIxs = async (
 
 		// fallback to normal limit order with auction params
 		if (!createdPlaceAndTakeIx) {
-			allOrders.push(limitAuctionOrderParams);
+			allOrders.push({
+				...limitAuctionOrderParams,
+				...(builderParams && {
+					builderIdx: builderParams.builderIdx,
+					builderFeeTenthBps: builderParams.builderFeeTenthBps,
+				}),
+			});
 		}
 	} else {
 		const orderParams = buildNonMarketOrderParams({
@@ -307,7 +333,13 @@ export const createOpenPerpNonMarketOrderIxs = async (
 			userOrderId,
 		});
 
-		allOrders.push(orderParams);
+		allOrders.push({
+			...orderParams,
+			...(builderParams && {
+				builderIdx: builderParams.builderIdx,
+				builderFeeTenthBps: builderParams.builderFeeTenthBps,
+			}),
+		});
 	}
 
 	const bracketOrdersDirection = ENUM_UTILS.match(

--- a/common-ts/src/drift/base/actions/trade/openPerpOrder/openPerpNonMarketOrder/index.ts
+++ b/common-ts/src/drift/base/actions/trade/openPerpOrder/openPerpNonMarketOrder/index.ts
@@ -33,6 +33,7 @@ import {
 	SwiftLimitOrderParamsOrderConfig,
 	NonMarketOrderParamsConfig,
 	IsolatedPositionDepositsOverride,
+	BuilderParams,
 } from '../types';
 import { WithTxnParams } from '../../../../types';
 import { getPositionMaxLeverageIxIfNeeded } from '../positionMaxLeverage';
@@ -76,10 +77,7 @@ export interface OpenPerpNonMarketOrderBaseParams
 	/**
 	 * Optional builder code parameters for revenue sharing.
 	 */
-	builderParams?: {
-		builderIdx: number;
-		builderFeeTenthBps: number;
-	};
+	builderParams?: BuilderParams;
 }
 
 export interface OpenPerpNonMarketOrderParamsWithSwift
@@ -118,10 +116,7 @@ export const createMultipleOpenPerpNonMarketOrderIx = async (params: {
 	/**
 	 * Optional builder code parameters for revenue sharing, applied to every order in the batch.
 	 */
-	builderParams?: {
-		builderIdx: number;
-		builderFeeTenthBps: number;
-	};
+	builderParams?: BuilderParams;
 }): Promise<TransactionInstruction> => {
 	const {
 		velocityClient,
@@ -132,10 +127,7 @@ export const createMultipleOpenPerpNonMarketOrderIx = async (params: {
 
 	const orderParams = orderParamsConfigs.map((config) => ({
 		...buildNonMarketOrderParams(config),
-		...(builderParams && {
-			builderIdx: builderParams.builderIdx,
-			builderFeeTenthBps: builderParams.builderFeeTenthBps,
-		}),
+		...(builderParams ?? {}),
 	}));
 
 	const placeOrderIx = await velocityClient.getPlaceOrdersIx(
@@ -315,10 +307,7 @@ export const createOpenPerpNonMarketOrderIxs = async (
 		if (!createdPlaceAndTakeIx) {
 			allOrders.push({
 				...limitAuctionOrderParams,
-				...(builderParams && {
-					builderIdx: builderParams.builderIdx,
-					builderFeeTenthBps: builderParams.builderFeeTenthBps,
-				}),
+				...(builderParams ?? {}),
 			});
 		}
 	} else {
@@ -335,10 +324,7 @@ export const createOpenPerpNonMarketOrderIxs = async (
 
 		allOrders.push({
 			...orderParams,
-			...(builderParams && {
-				builderIdx: builderParams.builderIdx,
-				builderFeeTenthBps: builderParams.builderFeeTenthBps,
-			}),
+			...(builderParams ?? {}),
 		});
 	}
 

--- a/common-ts/src/drift/base/actions/trade/openPerpOrder/types.ts
+++ b/common-ts/src/drift/base/actions/trade/openPerpOrder/types.ts
@@ -3,7 +3,7 @@ import {
 	MarketType,
 	PositionDirection,
 	PostOnlyParams,
-	ReferrerInfo,
+	RevenueShareEscrowAccount,
 } from '@velocity-exchange/sdk';
 import { Transaction, VersionedTransaction } from '@solana/web3.js';
 import { OptionalAuctionParamsRequestInputs } from './dlobServer';
@@ -40,7 +40,12 @@ export type PlaceAndTakeParams =
 	| {
 			enable: true;
 			auctionDurationPercentage?: number;
-			referrerInfo: ReferrerInfo | undefined;
+			/**
+			 * The taker's decoded RevenueShareEscrow account. Must be supplied when the
+			 * taker is referred (has a RevenueShareEscrow with a referrer) so the program's
+			 * fill-time enforcement can load it; otherwise the fill rejects.
+			 */
+			takerEscrow?: RevenueShareEscrowAccount;
 	  };
 
 export type NonMarketOrderType =
@@ -57,7 +62,7 @@ export interface LimitAuctionConfig {
 	optionalLimitAuctionParams?: OptionalAuctionParamsRequestInputs;
 	usePlaceAndTake?: {
 		enable: boolean;
-		referrerInfo?: ReferrerInfo; // needed for place and take fallback
+		takerEscrow?: RevenueShareEscrowAccount; // attached when the taker is referred
 		auctionDurationPercentage?: number;
 	};
 	onAuctionParamsFetched?: AuctionParamsFetchedCallback;

--- a/common-ts/src/drift/base/actions/trade/openPerpOrder/types.ts
+++ b/common-ts/src/drift/base/actions/trade/openPerpOrder/types.ts
@@ -68,6 +68,11 @@ export interface LimitAuctionConfig {
 	onAuctionParamsFetched?: AuctionParamsFetchedCallback;
 }
 
+export type BuilderParams = {
+	builderIdx: number;
+	builderFeeTenthBps: number;
+};
+
 export interface OptionalTriggerOrderParams {
 	baseAssetAmount?: BN;
 	triggerPrice: BN;

--- a/common-ts/src/drift/utils/auctionParamsResponseMapper.ts
+++ b/common-ts/src/drift/utils/auctionParamsResponseMapper.ts
@@ -20,7 +20,7 @@ export interface MappedAuctionParams {
 	immediateOrCancel?: boolean;
 	triggerPrice?: BN | null;
 	triggerCondition?: OrderTriggerCondition;
-	oraclePriceOffset?: number | null;
+	oraclePriceOffset?: BN | null;
 	auctionDuration: number | undefined;
 	maxTs?: BN | null;
 	auctionStartPrice: BN | undefined;
@@ -78,7 +78,6 @@ const FIELD_MAPPING: Record<keyof ServerAuctionParams, FieldConfig> = {
 	userOrderId: { type: 'number' },
 	marketIndex: { type: 'number' },
 	auctionDuration: { type: 'number' },
-	oraclePriceOffset: { type: 'number' },
 
 	// Booleans
 	reduceOnly: { type: 'boolean' },
@@ -92,6 +91,7 @@ const FIELD_MAPPING: Record<keyof ServerAuctionParams, FieldConfig> = {
 	// Nullable BNs
 	triggerPrice: { type: 'bn_nullable' },
 	maxTs: { type: 'bn_nullable' },
+	oraclePriceOffset: { type: 'bn_nullable' },
 };
 
 // Type conversion functions

--- a/common-ts/src/drift/utils/orderParams.ts
+++ b/common-ts/src/drift/utils/orderParams.ts
@@ -177,7 +177,7 @@ export function buildNonMarketOrderParams({
 			direction,
 			baseAssetAmount,
 			price: ZERO,
-			oraclePriceOffset: orderConfig.oraclePriceOffset.toNumber(),
+			oraclePriceOffset: orderConfig.oraclePriceOffset,
 			userOrderId,
 			postOnly,
 			reduceOnly,

--- a/common-ts/src/scripts/update-velocity-error-codes.js
+++ b/common-ts/src/scripts/update-velocity-error-codes.js
@@ -1,6 +1,8 @@
 const fs = require('fs');
 const path = require('path');
-const clearingHouseData = require('../../../protocol/sdk/src/idl/drift.json');
+const velocityIdl = require(require.resolve(
+	'@velocity-exchange/sdk/src/idl/velocity.json'
+));
 
 let uiErrors = {
 	errorsList: {},
@@ -21,7 +23,7 @@ try {
 // UI will use this to map the error code (number) to the name, so we can keep our manually added messages identified by the name but independent of the number
 uiErrors.errorCodesMap = {};
 
-clearingHouseData.errors.forEach((err) => {
+velocityIdl.errors.forEach((err) => {
 	uiErrors.errorCodesMap[err.code] = err.name;
 	if (!uiErrors.errorsList[err.name]) {
 		uiErrors.errorsList[err.name] = err;

--- a/common-ts/src/serializableTypes.ts
+++ b/common-ts/src/serializableTypes.ts
@@ -83,15 +83,6 @@ const BNSerializeAndDeserializeFns = {
 	Deserialize: BNDeserializationFn,
 };
 
-const BNArraySerializationFn = (target: BN[]) =>
-	target.map((val) => (val ? val.toString() : undefined));
-const BNArrayDeserializationFn = (values: string[]) =>
-	values.map((val) => (val ? new BN(val) : undefined));
-const BNArraySerializeAndDeserializeFns = {
-	Serialize: BNArraySerializationFn,
-	Deserialize: BNArrayDeserializationFn,
-};
-
 const QuoteBigNumSerializationFn = (target: BigNum | BN) =>
 	target
 		? target instanceof BigNum
@@ -209,6 +200,13 @@ const PriceBigNumDeserializationFn = (val: string | number) =>
 const PriceBigNumSerializeAndDeserializeFns = {
 	Serialize: PriceBigNumSerializationFn,
 	Deserialize: PriceBigNumDeserializationFn,
+};
+
+const NullablePriceBigNumSerializeAndDeserializeFns = {
+	Serialize: (target: BigNum | BN | null) =>
+		target === null ? null : PriceBigNumSerializationFn(target),
+	Deserialize: (val: string | number | null) =>
+		val === null ? null : PriceBigNumDeserializationFn(val),
 };
 
 // Funding rate and bank cumulative interest serialize identically to price
@@ -529,6 +527,9 @@ export class SerializableOrderActionRecord
 	makerExistingQuoteEntryAmount: BN | null;
 	@autoserializeUsing(BNSerializeAndDeserializeFns)
 	makerExistingBaseAssetAmount: BN | null;
+	@autoserializeUsing(BNSerializeAndDeserializeFns) triggerPrice: BN | null;
+	@autoserializeAs(Number) builderIdx: number | null;
+	@autoserializeUsing(BNSerializeAndDeserializeFns) builderFee: BN | null;
 
 	static onDeserialized(
 		data: JsonObject,
@@ -793,6 +794,11 @@ export class UISerializableOrderActionRecordBase {
 	makerExistingQuoteEntryAmount: BigNum | null;
 	@autoserializeUsing(NullableMarketBasedBigNumSerializeAndDeserializeFns)
 	makerExistingBaseAssetAmount: BigNum | null;
+	@autoserializeUsing(NullablePriceBigNumSerializeAndDeserializeFns)
+	triggerPrice: BigNum | null;
+	@autoserializeAs(Number) builderIdx: number | null;
+	@autoserializeUsing(NullableQuoteBigNumSerializeAndDeserializeFns)
+	builderFee: BigNum | null;
 }
 
 @inheritSerialization(UISerializableOrderActionRecordBase)
@@ -922,6 +928,8 @@ export class SerializableDepositRecord implements DepositRecordEvent {
 	@autoserializeUsing(BNSerializeAndDeserializeFns) totalWithdrawsAfter: BN;
 	@autoserializeUsing(EnumSerializeAndDeserializeFns)
 	explanation: DepositExplanation;
+	@autoserializeUsing(PublicKeySerializeAndDeserializeFns) signer?: PublicKey;
+	@autoserializeUsing(BNSerializeAndDeserializeFns) userTokenAmountAfter: BN;
 }
 
 @inheritSerialization(SerializableDepositRecord)
@@ -958,6 +966,10 @@ export class UISerializableDepositRecord extends SerializableDepositRecord {
 	//@ts-ignore
 	totalWithdrawsAfter: BigNum;
 
+	@autoserializeUsing(MarketBasedBigNumSerializeAndDeserializeFns)
+	//@ts-ignore
+	userTokenAmountAfter: BigNum;
+
 	static onDeserialized(
 		data: JsonObject,
 		instance: UISerializableDepositRecord
@@ -968,7 +980,12 @@ export class UISerializableDepositRecord extends SerializableDepositRecord {
 			data,
 			instance,
 			getPrecisionToUse(MarketType.SPOT, instance.marketIndex),
-			['amount', 'marketDepositBalance', 'marketWithdrawBalance']
+			[
+				'amount',
+				'marketDepositBalance',
+				'marketWithdrawBalance',
+				'userTokenAmountAfter',
+			]
 		);
 	}
 }
@@ -1167,21 +1184,17 @@ export class UISerializableFundingPaymentRecord extends SerializableFundingPayme
 }
 
 //// Liquidation Records
-// @ts-ignore
 export class SerializableLiquidatePerpRecord implements LiquidatePerpRecord {
 	@autoserializeAs(Number) marketIndex: number;
-	@autoserializeUsing(BNArraySerializeAndDeserializeFns) orderIds: BN[];
 	@autoserializeUsing(BNSerializeAndDeserializeFns) oraclePrice: BN;
 	@autoserializeUsing(BNSerializeAndDeserializeFns) baseAssetAmount: BN;
 	@autoserializeUsing(BNSerializeAndDeserializeFns) quoteAssetAmount: BN;
-	@autoserializeUsing(BNSerializeAndDeserializeFns) userPnl: BN;
-	@autoserializeUsing(BNSerializeAndDeserializeFns) liquidatorPnl: BN;
-	@autoserializeUsing(BNSerializeAndDeserializeFns) canceledOrdersFee: BN;
-	@autoserializeUsing(BNSerializeAndDeserializeFns) userOrderId: BN;
-	@autoserializeUsing(BNSerializeAndDeserializeFns) liquidatorOrderId: BN;
+	@autoserializeAs(Number) userOrderId: number;
+	@autoserializeAs(Number) liquidatorOrderId: number;
 	@autoserializeUsing(BNSerializeAndDeserializeFns) fillRecordId: BN;
 	@autoserializeUsing(BNSerializeAndDeserializeFns) liquidatorFee: BN;
 	@autoserializeUsing(BNSerializeAndDeserializeFns) ifFee: BN;
+	@autoserializeUsing(BNSerializeAndDeserializeFns) protocolFee: BN;
 }
 
 @inheritSerialization(SerializableLiquidatePerpRecord)
@@ -1197,19 +1210,13 @@ export class UISerializableLiquidatePerpRecord extends SerializableLiquidatePerp
 	quoteAssetAmount: BigNum;
 	@autoserializeUsing(QuoteBigNumSerializeAndDeserializeFns)
 	//@ts-ignore
-	userPnl: BigNum;
-	@autoserializeUsing(QuoteBigNumSerializeAndDeserializeFns)
-	//@ts-ignore
-	liquidatorPnl: BigNum;
-	@autoserializeUsing(QuoteBigNumSerializeAndDeserializeFns)
-	//@ts-ignore
-	canceledOrdersFee: BigNum;
-	@autoserializeUsing(QuoteBigNumSerializeAndDeserializeFns)
-	//@ts-ignore
 	liquidatorFee: BigNum;
 	@autoserializeUsing(QuoteBigNumSerializeAndDeserializeFns)
 	//@ts-ignore
 	ifFee: BigNum;
+	@autoserializeUsing(QuoteBigNumSerializeAndDeserializeFns)
+	//@ts-ignore
+	protocolFee: BigNum;
 }
 
 export class SerializableLiquidateSpotRecord implements LiquidateSpotRecord {
@@ -1220,6 +1227,7 @@ export class SerializableLiquidateSpotRecord implements LiquidateSpotRecord {
 	@autoserializeUsing(BNSerializeAndDeserializeFns) liabilityPrice: BN;
 	@autoserializeUsing(BNSerializeAndDeserializeFns) liabilityTransfer: BN;
 	@autoserializeUsing(BNSerializeAndDeserializeFns) ifFee: BN;
+	@autoserializeUsing(BNSerializeAndDeserializeFns) protocolFee: BN;
 }
 
 @inheritSerialization(SerializableLiquidateSpotRecord)
@@ -1400,9 +1408,10 @@ export class SerializableLiquidationRecord implements LiquidationRecordEvent {
 	perpBankruptcy: PerpBankruptcyRecord;
 	@autoserializeAs(SerializableSpotBankruptcyRecord)
 	spotBankruptcy: SpotBankruptcyRecord;
-	@autoserializeUsing(BNArraySerializeAndDeserializeFns) canceledOrderIds: BN[];
+	@autoserializeAsArray(Number) canceledOrderIds: number[];
 	@autoserializeUsing(BNSerializeAndDeserializeFns) marginFreed: BN;
 	@autoserializeAs(Boolean) bankrupt: boolean;
+	@autoserializeAs(Number) bitFlags: number;
 }
 
 @inheritSerialization(SerializableLiquidationRecord)
@@ -1445,8 +1454,9 @@ export class UISerializableLiquidationRecordV2 {
 	@autoserializeUsing(QuoteBigNumSerializeAndDeserializeFns) marginFreed: BN;
 	@autoserializeAs(Number) liquidationId: number;
 	@autoserializeAs(Boolean) bankrupt: boolean;
-	@autoserializeUsing(BNArraySerializeAndDeserializeFns)
-	canceledOrderIds: BN[];
+	@autoserializeAs(Number) bitFlags: number;
+	@autoserializeAsArray(Number)
+	canceledOrderIds: number[];
 
 	// Liquidate Perp
 	@autoserializeAs(Number) liquidatePerp_marketIndex: number;
@@ -1458,22 +1468,16 @@ export class UISerializableLiquidationRecordV2 {
 	liquidatePerp_quoteAssetAmount: BigNum;
 	@autoserializeUsing(BNSerializeAndDeserializeFns)
 	liquidatePerp_fillRecordId: BN;
-	@autoserializeUsing(BNSerializeAndDeserializeFns)
-	liquidatePerp_userOrderId: BN;
-	@autoserializeUsing(BNSerializeAndDeserializeFns)
-	liquidatePerp_liquidatorOrderId: BN;
+	@autoserializeAs(Number)
+	liquidatePerp_userOrderId: number;
+	@autoserializeAs(Number)
+	liquidatePerp_liquidatorOrderId: number;
 	@autoserializeUsing(QuoteBigNumSerializeAndDeserializeFns)
 	liquidatePerp_liquidatorFee: BigNum;
 	@autoserializeUsing(QuoteBigNumSerializeAndDeserializeFns)
 	liquidatePerp_ifFee: BigNum;
-	@autoserializeUsing(BNArraySerializeAndDeserializeFns)
-	liquidatePerp_orderIds: BN[];
 	@autoserializeUsing(QuoteBigNumSerializeAndDeserializeFns)
-	liquidatePerp_userPnl: BigNum;
-	@autoserializeUsing(QuoteBigNumSerializeAndDeserializeFns)
-	liquidatePerp_liquidatorPnl: BigNum;
-	@autoserializeUsing(QuoteBigNumSerializeAndDeserializeFns)
-	liquidatePerp_canceledOrdersFee: BigNum;
+	liquidatePerp_protocolFee: BigNum;
 
 	// Liquidate Spot
 	@autoserializeAs(Number) liquidateSpot_assetMarketIndex: number;
@@ -1488,6 +1492,8 @@ export class UISerializableLiquidationRecordV2 {
 	liquidateSpot_liabilityTransfer: BigNum;
 	@autoserializeUsing(MarketBasedBigNumSerializeAndDeserializeFns)
 	liquidateSpot_ifFee: BigNum;
+	@autoserializeUsing(MarketBasedBigNumSerializeAndDeserializeFns)
+	liquidateSpot_protocolFee: BigNum;
 
 	// Liquidate Borrow For Perp PnL
 	@autoserializeAs(Number) liquidateBorrowForPerpPnl_perpMarketIndex: number;
@@ -2211,7 +2217,7 @@ export function transformDataApiOrderRecordToSerializableOrderRecord(
 			baseAssetAmountFilled: deserializedV2Record.baseAssetAmountFilled.val,
 			quoteAssetAmountFilled: deserializedV2Record.quoteAssetAmountFilled.val,
 			triggerPrice: deserializedV2Record.triggerPrice.val,
-			oraclePriceOffset: deserializedV2Record.oraclePriceOffset.toNum(),
+			oraclePriceOffset: deserializedV2Record.oraclePriceOffset.val,
 			auctionStartPrice: deserializedV2Record.auctionStartPrice.val,
 			auctionEndPrice: deserializedV2Record.auctionEndPrice.val,
 			orderType: deserializedV2Record.orderType,
@@ -2353,6 +2359,7 @@ export function transformDataApiLiquidationRecordToUISerializableLiquidationReco
 		marginRequirement: deserializedV2Record.marginRequirement,
 		marginFreed: deserializedV2Record.marginFreed,
 		bankrupt: deserializedV2Record.bankrupt,
+		bitFlags: deserializedV2Record.bitFlags,
 		canceledOrderIds: deserializedV2Record.canceledOrderIds,
 		liquidatePerp: {
 			marketIndex: deserializedV2Record.liquidatePerp_marketIndex,
@@ -2364,10 +2371,7 @@ export function transformDataApiLiquidationRecordToUISerializableLiquidationReco
 			liquidatorOrderId: deserializedV2Record.liquidatePerp_liquidatorOrderId,
 			liquidatorFee: deserializedV2Record.liquidatePerp_liquidatorFee,
 			ifFee: deserializedV2Record.liquidatePerp_ifFee,
-			orderIds: deserializedV2Record.liquidatePerp_orderIds,
-			userPnl: deserializedV2Record.liquidatePerp_userPnl,
-			liquidatorPnl: deserializedV2Record.liquidatePerp_liquidatorPnl,
-			canceledOrdersFee: deserializedV2Record.liquidatePerp_canceledOrdersFee,
+			protocolFee: deserializedV2Record.liquidatePerp_protocolFee,
 		},
 		liquidateSpot: {
 			assetMarketIndex: deserializedV2Record.liquidateSpot_assetMarketIndex,
@@ -2377,8 +2381,9 @@ export function transformDataApiLiquidationRecordToUISerializableLiquidationReco
 				deserializedV2Record.liquidateSpot_liabilityMarketIndex,
 			liabilityPrice: deserializedV2Record.liquidateSpot_liabilityPrice,
 			liabilityTransfer: deserializedV2Record.liquidateSpot_liabilityTransfer,
-			// V2 has ifFee as BigNum, V1 expects BN
+			// V2 has ifFee/protocolFee as BigNum, V1 expects BN
 			ifFee: deserializedV2Record.liquidateSpot_ifFee?.val,
+			protocolFee: deserializedV2Record.liquidateSpot_protocolFee?.val,
 		},
 		liquidateBorrowForPerpPnl: {
 			perpMarketIndex:

--- a/common-ts/src/utils/dlob-server/DlobServerWebsocketUtils.ts
+++ b/common-ts/src/utils/dlob-server/DlobServerWebsocketUtils.ts
@@ -16,14 +16,14 @@ type BaseSubscriptionOutputProps<T extends DlobServerChannel> = {
 
 interface OrderbookSubscriptionOutputProps
 	extends BaseSubscriptionOutputProps<'orderbook' | 'orderbook_indicative'> {
-	marketType: 'perp' | 'spot';
+	marketType: 'perp';
 	market: string;
 	grouping?: OrderbookGrouping;
 }
 
 interface TradeSubscriptionOutputProps
 	extends BaseSubscriptionOutputProps<'trades'> {
-	marketType: 'perp' | 'spot';
+	marketType: 'perp';
 	market: string;
 }
 
@@ -38,14 +38,14 @@ type BaseUnsubscriptionOutputProps<T extends DlobServerChannel> = {
 
 interface OrderbookUnsubscriptionOutputProps
 	extends BaseUnsubscriptionOutputProps<'orderbook' | 'orderbook_indicative'> {
-	marketType: 'perp' | 'spot';
+	marketType: 'perp';
 	market: string;
 	grouping?: OrderbookGrouping;
 }
 
 interface TradeUnsubscriptionOutputProps
 	extends BaseUnsubscriptionOutputProps<'trades'> {
-	marketType: 'perp' | 'spot';
+	marketType: 'perp';
 	market: string;
 }
 
@@ -80,24 +80,24 @@ export type WebsocketServerResponse = {
 };
 
 const getMarketSymbolFromId = (marketId: MarketId) => {
-	const isPerp = marketId.isPerp;
+	const perpMarket = UIMarket.perpMarkets.find(
+		(m) => marketId.marketIndex === m.marketIndex
+	);
+	return perpMarket?.symbol ?? '';
+};
 
-	if (isPerp) {
-		const perpMarket = UIMarket.perpMarkets.find(
-			(m) => marketId.marketIndex === m.marketIndex
+const assertPerpMarket = (market: MarketId) => {
+	if (!market.isPerp) {
+		throw new Error(
+			`DlobServerWebsocketUtils only supports perp markets; got spot market index ${market.marketIndex}`
 		);
-		return perpMarket?.symbol ?? '';
-	} else {
-		const spotMarket = UIMarket.spotMarkets.find(
-			(m) => marketId.marketIndex === m.marketIndex
-		);
-		return spotMarket?.symbol ?? '';
 	}
 };
 
 const getSubscriptionProps = (
 	props: WebsocketSubscriptionProps
 ): WebsocketSubscriptionOutputProps => {
+	assertPerpMarket(props.market);
 	const type = props.type;
 
 	switch (type) {
@@ -106,7 +106,7 @@ const getSubscriptionProps = (
 				type: 'subscribe',
 				channel: 'orderbook',
 				market: getMarketSymbolFromId(props.market),
-				marketType: props.market.isPerp ? 'perp' : 'spot',
+				marketType: 'perp',
 				...(props.grouping && { grouping: props.grouping }),
 			};
 		}
@@ -115,7 +115,7 @@ const getSubscriptionProps = (
 				type: 'subscribe',
 				channel: 'orderbook_indicative',
 				market: getMarketSymbolFromId(props.market),
-				marketType: props.market.isPerp ? 'perp' : 'spot',
+				marketType: 'perp',
 				...(props.grouping && { grouping: props.grouping }),
 			};
 		}
@@ -124,7 +124,7 @@ const getSubscriptionProps = (
 				type: 'subscribe',
 				channel: 'trades',
 				market: getMarketSymbolFromId(props.market),
-				marketType: props.market.isPerp ? 'perp' : 'spot',
+				marketType: 'perp',
 			};
 		}
 		default: {
@@ -137,6 +137,7 @@ const getSubscriptionProps = (
 const getUnsubscriptionProps = (
 	props: WebsocketSubscriptionProps
 ): WebsocketUnsubscriptionOutputProps => {
+	assertPerpMarket(props.market);
 	const type = props.type;
 
 	switch (type) {
@@ -145,7 +146,7 @@ const getUnsubscriptionProps = (
 				type: 'unsubscribe',
 				channel: 'orderbook',
 				market: getMarketSymbolFromId(props.market),
-				marketType: props.market.isPerp ? 'perp' : 'spot',
+				marketType: 'perp',
 				...(props.grouping && { grouping: props.grouping }),
 			};
 		}
@@ -154,7 +155,7 @@ const getUnsubscriptionProps = (
 				type: 'unsubscribe',
 				channel: 'orderbook_indicative',
 				market: getMarketSymbolFromId(props.market),
-				marketType: props.market.isPerp ? 'perp' : 'spot',
+				marketType: 'perp',
 				...(props.grouping && { grouping: props.grouping }),
 			};
 		}
@@ -163,7 +164,7 @@ const getUnsubscriptionProps = (
 				type: 'unsubscribe',
 				channel: 'trades',
 				market: getMarketSymbolFromId(props.market),
-				marketType: props.market.isPerp ? 'perp' : 'spot',
+				marketType: 'perp',
 			};
 		}
 		default: {
@@ -183,19 +184,17 @@ const getChannelKey = (props: WebsocketSubscriptionProps) => {
 
 	switch (type) {
 		case 'orderbook': {
-			return `orderbook_${props.market.isPerp ? 'perp' : 'spot'}_${
-				props.market.marketIndex
-			}${props.grouping ? `_grouped_${props.grouping}` : ''}`;
+			return `orderbook_perp_${props.market.marketIndex}${
+				props.grouping ? `_grouped_${props.grouping}` : ''
+			}`;
 		}
 		case 'orderbook_indicative': {
-			return `orderbook_${props.market.isPerp ? 'perp' : 'spot'}_${
-				props.market.marketIndex
-			}${props.grouping ? `_grouped_${props.grouping}` : ''}_indicative`;
+			return `orderbook_perp_${props.market.marketIndex}${
+				props.grouping ? `_grouped_${props.grouping}` : ''
+			}_indicative`;
 		}
 		case 'trades': {
-			return `trades_${props.market.isPerp ? 'perp' : 'spot'}_${
-				props.market.marketIndex
-			}`;
+			return `trades_perp_${props.market.marketIndex}`;
 		}
 		default: {
 			const exhaustiveCheck: never = type;
@@ -217,7 +216,7 @@ const getMessageFilter = (
 					message.channel === getChannelKey(props) ||
 					// This is a special extra message which comes through once, immediately after subscribing, to let the subscriber know the initial state of the orderbook
 					message.channel ===
-						`last_update_orderbook_${props.market.marketTypeStr}_${props.market.marketIndex}`
+						`last_update_orderbook_perp_${props.market.marketIndex}`
 				);
 			};
 		}

--- a/common-ts/tests/oracleCrank/oracleSourceHelpers.test.ts
+++ b/common-ts/tests/oracleCrank/oracleSourceHelpers.test.ts
@@ -1,29 +1,12 @@
 import { OracleSource } from '@velocity-exchange/sdk';
 import { expect } from 'chai';
 import {
-	isPythPull,
 	isPythLazer,
 	isPythOracle,
 	isPullOracle,
 } from '../../src/drift/base/actions/markets/oracleCrank/oracleSourceHelpers';
 
 describe('Oracle Source Helpers', () => {
-	describe('isPythPull', () => {
-		it('should return true for PYTH_PULL variants', () => {
-			expect(isPythPull(OracleSource.PYTH_PULL)).to.be.true;
-			expect(isPythPull(OracleSource.PYTH_1K_PULL)).to.be.true;
-			expect(isPythPull(OracleSource.PYTH_1M_PULL)).to.be.true;
-			expect(isPythPull(OracleSource.PYTH_STABLE_COIN_PULL)).to.be.true;
-		});
-
-		it('should return false for non-PYTH_PULL sources', () => {
-			expect(isPythPull(OracleSource.PYTH_LAZER)).to.be.false;
-			expect(isPythPull(OracleSource.SWITCHBOARD_ON_DEMAND)).to.be.false;
-			expect(isPythPull(OracleSource.QUOTE_ASSET)).to.be.false;
-			expect(isPythPull(OracleSource.PYTH)).to.be.false;
-		});
-	});
-
 	describe('isPythLazer', () => {
 		it('should return true for PYTH_LAZER variants', () => {
 			expect(isPythLazer(OracleSource.PYTH_LAZER)).to.be.true;

--- a/react/bun.lock
+++ b/react/bun.lock
@@ -23,7 +23,7 @@
         "@solana/spl-token": "0.3.8",
         "@solana/web3.js": "1.98.0",
         "@types/react": "npm:types-react@19.0.0-rc.1",
-        "@velocity-exchange/sdk": "0.2.3",
+        "@velocity-exchange/sdk": "0.2.4",
         "copyfiles": "2.4.1",
         "encoding": "0.1.13",
         "eslint": "8.43.0",
@@ -36,7 +36,7 @@
       "peerDependencies": {
         "@solana/spl-token": "0.3.8",
         "@solana/web3.js": "1.98.0",
-        "@velocity-exchange/sdk": "0.2.3",
+        "@velocity-exchange/sdk": "0.2.4",
         "react": "19.0.3",
         "react-dom": "19.0.3",
       },
@@ -876,7 +876,7 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.56.0", "", { "dependencies": { "@typescript-eslint/types": "8.56.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg=="],
 
-    "@velocity-exchange/sdk": ["@velocity-exchange/sdk@0.2.3", "", { "dependencies": { "@anchor-lang/core": "1.0.1", "@coral-xyz/anchor": "npm:@anchor-lang/core@1.0.1", "@coral-xyz/anchor-29": "npm:@coral-xyz/anchor@0.29.0", "@msgpack/msgpack": "3.1.2", "@noble/hashes": "1.7.1", "@pythnetwork/client": "2.5.3", "@pythnetwork/price-service-sdk": "1.7.1", "@pythnetwork/pyth-lazer-sdk": "6.0.0", "@solana/buffer-layout": "4.0.1", "@solana/spl-token": "0.4.13", "@solana/web3.js": "1.98.0", "@triton-one/yellowstone-grpc": "5.0.5", "anchor-bankrun": "0.5.0", "bn.js": "^5.2.0", "bs58": "4.0.1", "gill": "0.10.2", "nanoid": "3.3.4", "node-cache": "5.1.2", "node-fetch": "2.7.0", "solana-bankrun": "0.4.0", "strict-event-emitter-types": "2.0.0", "tweetnacl": "1.0.3", "tweetnacl-util": "0.15.1", "uuid": "8.3.2", "ws": "8.18.1", "yargs": "17.7.2", "zod": "4.0.17", "zstddec": "0.1.0" }, "optionalDependencies": { "helius-laserstream": "0.1.8" } }, "sha512-y9/kAS07ExW8T6kuzcb7BFRN6lmDzWv6RPclSyezPuSQLrhFc5fBTDBcLfh8lNJM8VBNYViFOxA+Lp0FfQxnHw=="],
+    "@velocity-exchange/sdk": ["@velocity-exchange/sdk@0.2.4", "", { "dependencies": { "@anchor-lang/core": "1.0.1", "@coral-xyz/anchor": "npm:@anchor-lang/core@1.0.1", "@coral-xyz/anchor-29": "npm:@coral-xyz/anchor@0.29.0", "@msgpack/msgpack": "3.1.2", "@noble/hashes": "1.7.1", "@pythnetwork/client": "2.5.3", "@pythnetwork/price-service-sdk": "1.7.1", "@pythnetwork/pyth-lazer-sdk": "6.0.0", "@solana/buffer-layout": "4.0.1", "@solana/spl-token": "0.4.13", "@solana/web3.js": "1.98.0", "@triton-one/yellowstone-grpc": "5.0.5", "anchor-bankrun": "0.5.0", "bn.js": "^5.2.0", "bs58": "4.0.1", "gill": "0.10.2", "nanoid": "3.3.4", "node-cache": "5.1.2", "node-fetch": "2.7.0", "solana-bankrun": "0.4.0", "strict-event-emitter-types": "2.0.0", "tweetnacl": "1.0.3", "tweetnacl-util": "0.15.1", "uuid": "8.3.2", "ws": "8.18.1", "yargs": "17.7.2", "zod": "4.0.17", "zstddec": "0.1.0" }, "optionalDependencies": { "helius-laserstream": "0.1.8" } }, "sha512-O9KaDBEZqpcxCN6a7PDUxlIkU2c9PRboilYOV/dImPgC29g1Y+AQ5aFnn7vwdUCHGwv8ifRMHjh1ICt9E76Z6g=="],
 
     "@vue/compiler-core": ["@vue/compiler-core@3.5.28", "", { "dependencies": { "@babel/parser": "^7.29.0", "@vue/shared": "3.5.28", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-kviccYxTgoE8n6OCw96BNdYlBg2GOWfBuOW4Vqwrt7mSKWKwFVvI8egdTltqRgITGPsTFYtKYfxIG8ptX2PJHQ=="],
 

--- a/react/package.json
+++ b/react/package.json
@@ -20,7 +20,7 @@
 		"@solana/spl-token": "0.3.8",
 		"@solana/web3.js": "1.98.0",
 		"@types/react": "npm:types-react@19.0.0-rc.1",
-		"@velocity-exchange/sdk": "0.2.3",
+		"@velocity-exchange/sdk": "0.2.4",
 		"copyfiles": "2.4.1",
 		"encoding": "0.1.13",
 		"eslint": "8.43.0",
@@ -33,7 +33,7 @@
 	"peerDependencies": {
 		"@solana/spl-token": "0.3.8",
 		"@solana/web3.js": "1.98.0",
-		"@velocity-exchange/sdk": "0.2.3",
+		"@velocity-exchange/sdk": "0.2.4",
 		"react": "19.0.3",
 		"react-dom": "19.0.3"
 	},
@@ -64,6 +64,6 @@
 		"@solana/web3.js": "1.98.0",
 		"@solana/errors": "2.0.0-preview.4",
 		"@solana/codecs-data-structures": "2.0.0-preview.4",
-		"@velocity-exchange/sdk": "0.2.3"
+		"@velocity-exchange/sdk": "0.2.4"
 	}
 }


### PR DESCRIPTION
## Summary
- Bumps `@velocity-exchange/sdk` from 0.2.3 → 0.2.4 in `common-ts`
- Reconciles downstream code with SDK changes: updated `serializableTypes`, `DlobServerWebsocketUtils`, open-perp-order actions, and oracle-crank helpers to match the new SDK surface
- Regenerates autogenerated velocity error codes (`velocityErrors.json`)

## Test plan
- [ ] `bun run build` passes with no type errors
- [ ] `bun run test` — non-drift suite green (106 passing baseline)
- [ ] `bun run circular-deps` reports no cycles