### PR TITLE
refactor(common-ts): update referral model and SDK to 0.2.4

### DIFF
--- a/common-ts/src/drift/Velocity/clients/AuthorityVelocity/VelocityOperations/index.ts
+++ b/common-ts/src/drift/Velocity/clients/AuthorityVelocity/VelocityOperations/index.ts
@@ -131,7 +131,7 @@ export class VelocityOperations {
 			newAccountName,
 			maxLeverage,
 			poolId = MAIN_POOL_ID,
-			referrerName,
+			referral,
 		} = params;
 
 		const spotMarketConfig = getMarketConfig(
@@ -158,7 +158,7 @@ export class VelocityOperations {
 				authority: this.velocityClient.wallet.publicKey,
 				userStatsAccount: userStatsAccount,
 				accountName: newAccountName,
-				referrerName,
+				referral,
 				customMaxMarginRatio,
 				poolId,
 				txParams: this.getTxParams(),

--- a/common-ts/src/drift/Velocity/clients/AuthorityVelocity/VelocityOperations/types.ts
+++ b/common-ts/src/drift/Velocity/clients/AuthorityVelocity/VelocityOperations/types.ts
@@ -8,6 +8,7 @@ import {
 import { OptionalAuctionParamsRequestInputs } from '../../../../base/actions/trade/openPerpOrder/dlobServer';
 import { SwiftOrderOptions } from '../../../../base/actions/trade/openPerpOrder/openSwiftOrder';
 import { IsolatedPositionDepositsOverride } from '../../../../base/actions/trade/openPerpOrder/types';
+import { ReferralParams } from '../../../../base/actions/user/create';
 
 /**
  * Interface for deposit operation parameters.
@@ -40,7 +41,7 @@ export interface CreateUserAndDepositParams {
 	maxLeverage?: number;
 	poolId?: number;
 	subAccountId?: number;
-	referrerName?: string;
+	referral?: ReferralParams;
 }
 
 export interface CreateRevenueShareEscrowParams {

--- a/common-ts/src/drift/Velocity/clients/CentralServerVelocity/index.ts
+++ b/common-ts/src/drift/Velocity/clients/CentralServerVelocity/index.ts
@@ -69,7 +69,10 @@ import { SwiftLimitOrderParamsOrderConfig } from '../../../base/actions/trade/op
 import { createEditOrderTxn } from '../../../base/actions/trade/editOrder';
 import { createCancelOrdersTxn } from '../../../base/actions/trade/cancelOrder';
 import { createSwapTxn } from '../../../base/actions/trade/swap';
-import { createUserAndDepositCollateralBaseTxn } from '../../../base/actions/user/create';
+import {
+	createUserAndDepositCollateralBaseTxn,
+	ReferralParams,
+} from '../../../base/actions/user/create';
 import { deleteUserTxn } from '../../../base/actions/user/delete';
 import { createRevenueShareEscrowTxn } from '../../../base/actions/builder/createRevenueShareEscrow';
 import { createRevenueShareAccountTxn } from '../../../base/actions/builder/createRevenueShareAccount';
@@ -451,7 +454,7 @@ export class CentralServerVelocity {
 		amount: BN,
 		spotMarketIndex: number,
 		options?: {
-			referrerName?: string;
+			referral?: ReferralParams;
 			accountName?: string;
 			poolId?: number;
 			fromSubAccountId?: number;
@@ -498,7 +501,7 @@ export class CentralServerVelocity {
 					spotMarketConfig,
 					authority,
 					userStatsAccount,
-					referrerName: options?.referrerName,
+					referral: options?.referral,
 					accountName: options?.accountName,
 					poolId: options?.poolId,
 					fromSubAccountId: options?.fromSubAccountId,

--- a/common-ts/src/drift/base/actions/trade/openPerpOrder/openPerpMarketOrder/index.ts
+++ b/common-ts/src/drift/base/actions/trade/openPerpOrder/openPerpMarketOrder/index.ts
@@ -369,11 +369,6 @@ export const createPlaceAndTakePerpMarketOrderIx = async ({
 		fetchedOrderParams.auctionEndPrice = price;
 	}
 
-	if (builderParams) {
-		fetchedOrderParams.builderIdx = builderParams.builderIdx;
-		fetchedOrderParams.builderFeeTenthBps = builderParams.builderFeeTenthBps;
-	}
-
 	if (!topMakersResult || topMakersResult.length === 0) {
 		throw new NoTopMakersError('No top makers found', fetchedOrderParams);
 	}

--- a/common-ts/src/drift/base/actions/trade/openPerpOrder/openPerpMarketOrder/index.ts
+++ b/common-ts/src/drift/base/actions/trade/openPerpOrder/openPerpMarketOrder/index.ts
@@ -8,6 +8,8 @@ import {
 	getUserStatsAccountPublicKey,
 	OrderType,
 	RevenueShareEscrowAccount,
+	fetchRevenueShareEscrowAccount,
+	escrowHasReferrer,
 } from '@velocity-exchange/sdk';
 import {
 	PublicKey,
@@ -335,28 +337,44 @@ export const createPlaceAndTakePerpMarketOrderIx = async ({
 		? 'ask'
 		: 'bid';
 
-	const [fetchedOrderParams, topMakersResult] = await Promise.all([
-		fetchAuctionOrderParams({
-			velocityClient,
-			user,
-			assetType,
-			marketIndex,
-			marketType: MarketType.PERP,
-			direction,
-			amount,
-			reduceOnly,
-			dlobServerHttpUrl,
-			optionalAuctionParamsInputs,
-			onAuctionParamsFetched: callbacks?.onAuctionParamsFetched,
-		}),
-		fetchTopMakers({
-			dlobServerHttpUrl,
-			marketIndex,
-			marketType: MarketType.PERP,
-			side: counterPartySide,
-			limit: 4,
-		}),
-	]);
+	const [fetchedOrderParams, topMakersResult, resolvedTakerEscrow] =
+		await Promise.all([
+			fetchAuctionOrderParams({
+				velocityClient,
+				user,
+				assetType,
+				marketIndex,
+				marketType: MarketType.PERP,
+				direction,
+				amount,
+				reduceOnly,
+				dlobServerHttpUrl,
+				optionalAuctionParamsInputs,
+				onAuctionParamsFetched: callbacks?.onAuctionParamsFetched,
+			}),
+			fetchTopMakers({
+				dlobServerHttpUrl,
+				marketIndex,
+				marketType: MarketType.PERP,
+				side: counterPartySide,
+				limit: 4,
+			}),
+			// place_and_take fills the placing user's own order in-instruction, so a
+			// referred user's RevenueShareEscrow must be attached or the program rejects
+			// the fill with UnableToLoadRevenueShareAccount. Honor a caller-supplied
+			// escrow, otherwise fetch it and only attach it when it carries a referrer.
+			(async (): Promise<RevenueShareEscrowAccount | undefined> => {
+				if (takerEscrow) {
+					return takerEscrow;
+				}
+				const escrow = await fetchRevenueShareEscrowAccount(
+					velocityClient.connection,
+					velocityClient.program,
+					user.getUserAccountOrThrow().authority
+				);
+				return escrow && escrowHasReferrer(escrow) ? escrow : undefined;
+			})(),
+		]);
 
 	fetchedOrderParams.userOrderId = userOrderId;
 
@@ -391,7 +409,7 @@ export const createPlaceAndTakePerpMarketOrderIx = async ({
 		{
 			authority: mainSignerOverride,
 		},
-		takerEscrow
+		resolvedTakerEscrow
 	);
 
 	return placeAndTakeIx;

--- a/common-ts/src/drift/base/actions/trade/openPerpOrder/openPerpMarketOrder/index.ts
+++ b/common-ts/src/drift/base/actions/trade/openPerpOrder/openPerpMarketOrder/index.ts
@@ -369,6 +369,11 @@ export const createPlaceAndTakePerpMarketOrderIx = async ({
 		fetchedOrderParams.auctionEndPrice = price;
 	}
 
+	if (builderParams) {
+		fetchedOrderParams.builderIdx = builderParams.builderIdx;
+		fetchedOrderParams.builderFeeTenthBps = builderParams.builderFeeTenthBps;
+	}
+
 	if (!topMakersResult || topMakersResult.length === 0) {
 		throw new NoTopMakersError('No top makers found', fetchedOrderParams);
 	}

--- a/common-ts/src/drift/base/actions/trade/openPerpOrder/types.ts
+++ b/common-ts/src/drift/base/actions/trade/openPerpOrder/types.ts
@@ -41,9 +41,10 @@ export type PlaceAndTakeParams =
 			enable: true;
 			auctionDurationPercentage?: number;
 			/**
-			 * The taker's decoded RevenueShareEscrow account. Must be supplied when the
-			 * taker is referred (has a RevenueShareEscrow with a referrer) so the program's
-			 * fill-time enforcement can load it; otherwise the fill rejects.
+			 * Optional override for the taker's decoded RevenueShareEscrow account.
+			 * When omitted, it is fetched automatically for referred takers (whose escrow
+			 * carries a referrer) so the program's fill-time enforcement can load it.
+			 * Supply it to skip the fetch when the escrow is already cached.
 			 */
 			takerEscrow?: RevenueShareEscrowAccount;
 	  };
@@ -62,7 +63,7 @@ export interface LimitAuctionConfig {
 	optionalLimitAuctionParams?: OptionalAuctionParamsRequestInputs;
 	usePlaceAndTake?: {
 		enable: boolean;
-		takerEscrow?: RevenueShareEscrowAccount; // attached when the taker is referred
+		takerEscrow?: RevenueShareEscrowAccount; // optional override; auto-fetched for referred takers
 		auctionDurationPercentage?: number;
 	};
 	onAuctionParamsFetched?: AuctionParamsFetchedCallback;

--- a/common-ts/src/drift/base/actions/user/create.ts
+++ b/common-ts/src/drift/base/actions/user/create.ts
@@ -179,7 +179,8 @@ export const createUserAndDepositCollateralBaseIxs = async ({
 	if (referrerInfo && nextSubaccountId === 0) {
 		const initEscrowIx = await velocityClient.getInitializeRevenueShareEscrowIx(
 			authority,
-			referral?.escrowNumOrders ?? DEFAULT_REFERRAL_ESCROW_NUM_ORDERS
+			referral?.escrowNumOrders ?? DEFAULT_REFERRAL_ESCROW_NUM_ORDERS,
+			{ payer: externalWallet ?? authority }
 		);
 		ixs.push(initEscrowIx);
 	}

--- a/common-ts/src/drift/base/actions/user/create.ts
+++ b/common-ts/src/drift/base/actions/user/create.ts
@@ -20,13 +20,31 @@ import {
 } from '@solana/web3.js';
 import { checkIfUserAccountExists } from '../../../../utils/positions/user';
 
+// Concurrent order slots allocated for a referred user's RevenueShareEscrow at
+// signup. Matches the default used by createRevenueShareEscrowIx.
+const DEFAULT_REFERRAL_ESCROW_NUM_ORDERS = 16;
+
+/**
+ * Referral options for account creation. When provided, the new user is created
+ * with the referrer and a RevenueShareEscrow that referral rewards accrue into.
+ */
+export interface ReferralParams {
+	/** The referrer's registered referral name. */
+	name: string;
+	/**
+	 * Concurrent order slots to allocate in the referred user's RevenueShareEscrow
+	 * at signup. Defaults to 16.
+	 */
+	escrowNumOrders?: number;
+}
+
 interface CreateUserAndDepositCollateralBaseIxsParams {
 	velocityClient: VelocityClient;
 	amount: BN;
 	spotMarketConfig: SpotMarketConfig;
 	authority: PublicKey;
 	userStatsAccount: UserStatsAccount | undefined;
-	referrerName?: string;
+	referral?: ReferralParams;
 	accountName?: string;
 	poolId?: number;
 	fromSubAccountId?: number;
@@ -51,7 +69,7 @@ interface CreateUserAndDepositCollateralBaseIxsParams {
  * @param spotMarketConfig - The spot market config of the deposit collateral
  * @param authority - The public key of the account authority (wallet owner)
  * @param userStatsAccount - Existing user stats account, used to determine next sub-account ID
- * @param referrerName - Optional name of the referrer for referral tracking
+ * @param referral - Optional referral options (referrer name and escrow size)
  * @param accountName - Optional custom name for the account (defaults to pool-specific name)
  * @param poolId - The pool ID to associate the account with (defaults to MAIN_POOL_ID)
  * @param fromSubAccountId - Optional sub-account ID to transfer funds from
@@ -70,7 +88,7 @@ export const createUserAndDepositCollateralBaseIxs = async ({
 	spotMarketConfig,
 	authority,
 	userStatsAccount,
-	referrerName,
+	referral,
 	accountName,
 	poolId = MAIN_POOL_ID,
 	fromSubAccountId,
@@ -103,8 +121,8 @@ export const createUserAndDepositCollateralBaseIxs = async ({
 			depositSourceWallet
 		);
 	const referrerNameAccountPromise: Promise<ReferrerNameAccount | undefined> =
-		referrerName
-			? velocityClient.fetchReferrerNameAccount(referrerName)
+		referral
+			? velocityClient.fetchReferrerNameAccount(referral.name)
 			: Promise.resolve(undefined);
 	const subaccountExistsPromise = checkIfUserAccountExists(velocityClient, {
 		type: 'subAccountId',
@@ -152,6 +170,20 @@ export const createUserAndDepositCollateralBaseIxs = async ({
 		);
 	const ixs: TransactionInstruction[] = [...createAndDepositIxs];
 
+	// A referral is recorded by initializeUser setting userStats.referrer above.
+	// Referral rewards now accrue through the user's RevenueShareEscrow, and
+	// initializeRevenueShareEscrow reads userStats.referrer into the escrow (setting
+	// the BuilderReferral status), so a referred user needs the escrow created at
+	// signup. Only relevant on the first subaccount, where userStats — and its
+	// referrer — is created.
+	if (referrerInfo && nextSubaccountId === 0) {
+		const initEscrowIx = await velocityClient.getInitializeRevenueShareEscrowIx(
+			authority,
+			referral?.escrowNumOrders ?? DEFAULT_REFERRAL_ESCROW_NUM_ORDERS
+		);
+		ixs.push(initEscrowIx);
+	}
+
 	const nextSubAccountPublicKey = getUserAccountPublicKeySync(
 		velocityClient.program.programId,
 		authority,
@@ -193,7 +225,7 @@ interface CreateUserAndDepositCollateralBaseTxnParams
  * @param spotMarketConfig - The spot market config of the deposit collateral
  * @param authority - The public key of the account authority (wallet owner)
  * @param userStatsAccount - Existing user stats account, used to determine next sub-account ID
- * @param referrerName - Optional name of the referrer for referral tracking
+ * @param referral - Optional referral options (referrer name and escrow size)
  * @param accountName - Optional custom name for the account (defaults to pool-specific name)
  * @param poolId - The pool ID to associate the account with (defaults to MAIN_POOL_ID)
  * @param fromSubAccountId - Optional sub-account ID to transfer funds from
@@ -212,7 +244,7 @@ export const createUserAndDepositCollateralBaseTxn = async ({
 	spotMarketConfig,
 	authority,
 	userStatsAccount,
-	referrerName,
+	referral,
 	accountName,
 	poolId = MAIN_POOL_ID,
 	fromSubAccountId,
@@ -231,7 +263,7 @@ export const createUserAndDepositCollateralBaseTxn = async ({
 			spotMarketConfig,
 			authority,
 			userStatsAccount,
-			referrerName,
+			referral,
 			accountName,
 			poolId,
 			fromSubAccountId,

--- a/common-ts/src/drift/cli.ts
+++ b/common-ts/src/drift/cli.ts
@@ -28,6 +28,7 @@ import {
 	sendSwiftOrder,
 	SwiftOrderMessage,
 } from './base/actions/trade/openPerpOrder/openSwiftOrder';
+import { ReferralParams } from './base/actions/user/create';
 import { SwiftClient } from '../clients/swiftClient';
 import { MarketId } from '../types';
 
@@ -392,6 +393,9 @@ async function createUserAndDepositCommand(args: CliArgs): Promise<void> {
 	const marketIndexArg = args.marketIndex as string;
 	const amountArg = args.amount as string;
 	const referrerName = args.referrerName as string | undefined;
+	const referralEscrowNumOrdersArg = args.referralEscrowNumOrders as
+		| string
+		| undefined;
 	const accountName = args.accountName as string | undefined;
 	const poolIdArg = args.poolId as string | undefined;
 	const fromSubAccountIdArg = args.fromSubAccountId as string | undefined;
@@ -421,7 +425,7 @@ async function createUserAndDepositCommand(args: CliArgs): Promise<void> {
 	const amountBN = parseAmount(amountArg, precision);
 
 	const options: {
-		referrerName?: string;
+		referral?: ReferralParams;
 		accountName?: string;
 		poolId?: number;
 		fromSubAccountId?: number;
@@ -430,7 +434,16 @@ async function createUserAndDepositCommand(args: CliArgs): Promise<void> {
 	} = {};
 
 	if (referrerName) {
-		options.referrerName = referrerName;
+		let escrowNumOrders: number | undefined;
+		if (referralEscrowNumOrdersArg !== undefined) {
+			escrowNumOrders = parseInt(referralEscrowNumOrdersArg, 10);
+			if (isNaN(escrowNumOrders)) {
+				throw new Error(
+					`Invalid referralEscrowNumOrders: ${referralEscrowNumOrdersArg}`
+				);
+			}
+		}
+		options.referral = { name: referrerName, escrowNumOrders };
 	}
 
 	if (accountName) {
@@ -481,8 +494,13 @@ async function createUserAndDepositCommand(args: CliArgs): Promise<void> {
 	if (options.accountName) {
 		console.log(`📝 Account Name: ${options.accountName}`);
 	}
-	if (options.referrerName) {
-		console.log(`🙌 Referrer Name: ${options.referrerName}`);
+	if (options.referral) {
+		console.log(`🙌 Referrer Name: ${options.referral.name}`);
+		if (options.referral.escrowNumOrders !== undefined) {
+			console.log(
+				`🎟️ Referral Escrow Orders: ${options.referral.escrowNumOrders}`
+			);
+		}
 	}
 	if (options.poolId !== undefined) {
 		console.log(`🏊 Pool ID: ${options.poolId}`);
@@ -969,7 +987,7 @@ function showUsage(): void {
 
 	console.log('🆕 createUserAndDeposit');
 	console.log(
-		'  ts-node cli.ts createUserAndDeposit --marketIndex=<num> --amount=<num> [--accountName=<string>] [--referrerName=<string>] [--poolId=<num>] [--fromSubAccountId=<num>] [--customMaxMarginRatio=<num>] [--fromWallet=<pubkey> --forAuthority=<pubkey>]'
+		'  ts-node cli.ts createUserAndDeposit --marketIndex=<num> --amount=<num> [--accountName=<string>] [--referrerName=<string>] [--referralEscrowNumOrders=<num>] [--poolId=<num>] [--fromSubAccountId=<num>] [--customMaxMarginRatio=<num>] [--fromWallet=<pubkey> --forAuthority=<pubkey>]'
 	);
 	console.log(
 		'  Example: ts-node cli.ts createUserAndDeposit --marketIndex=0 --amount=100 --accountName="Primary"'


### PR DESCRIPTION
## Summary
- Updates `@velocity-exchange/sdk` to v0.2.4 and reconciles breaking changes across order and market actions (`openPerpMarketOrder`, `VelocityOperations`, `CentralServerVelocity`)
- Introduces `BuilderParams` type to consolidate repeated parameter patterns in `openPerpOrder` builders
- Extends user creation flow to support referral parameters and escrow allocation

## Test plan
- [ ] `bun run build` passes clean in common-ts
- [ ] `bun run test` passes (106 non-drift tests)
- [ ] `bun run circular-deps` reports no cycles
- [ ] User creation with referral params produces correct escrow allocation