### PR TITLE
refactor(common-ts): configurable url inputs

### DIFF
--- a/common-ts/src/clients/candleClient.ts
+++ b/common-ts/src/clients/candleClient.ts
@@ -38,6 +38,24 @@ import { CandleSubscriberSubscription, MarketDataFeed } from './marketDataFeed';
  * - Create a more advanced cache which can store more than the most recent 1000 candles, dynamically growing as more candles are added (for now seems unnecessary, rare for someone to go back further than 1000 candles)
  */
 
+/**
+ * Optional configuration for the CandleClient.
+ */
+export type CandleClientConfig = {
+	/**
+	 * Optional override for the base data API URL used when fetching candles over HTTP
+	 * (e.g. `https://data.velocity.exchange` or a same-origin path like `/api/data-proxy/dev`).
+	 *
+	 * When omitted, the URL is derived from EnvironmentConstants using the `env` passed to
+	 * each fetch. Useful in local dev to route candle requests through a same-origin proxy
+	 * to avoid CORS restrictions.
+	 *
+	 * Note: this only affects the HTTP candle fetch endpoint. Websocket candle
+	 * subscriptions are handled separately via the MarketDataFeed.
+	 */
+	dataApiUrl?: string;
+};
+
 // Used by the subscriber client to fetch candles from the data API
 type CandleFetchConfig = {
 	env: UIEnv;
@@ -45,6 +63,7 @@ type CandleFetchConfig = {
 	resolution: CandleResolution;
 	fromTs: number; // Seconds
 	toTs: number; // Seconds
+	dataApiUrl?: string; // Optional base data API URL override
 };
 
 // Used by the subscriber client to subscribe to the candles websocket endpoint
@@ -61,6 +80,7 @@ type CandleFetchUrlConfig = {
 	resolution: CandleResolution;
 	startTs?: number; // Seconds - now optional
 	countToFetch: number;
+	dataApiUrl?: string; // Optional base data API URL override
 };
 
 type CandleFetchResponseJson = {
@@ -103,11 +123,15 @@ const getMarketSymbolForMarketId = (marketId: MarketId, uiEnv: UIEnv) => {
 // This is the maximum number of candles that can be fetched in a single GET request
 const CANDLE_FETCH_LIMIT = 1000;
 
-const getBaseDataApiUrl = (env: UIEnv) => {
+const getBaseDataApiUrl = (env: UIEnv, dataApiUrlOverride?: string) => {
+	if (dataApiUrlOverride) {
+		// Strip any trailing slash so the path can be appended safely.
+		return dataApiUrlOverride.replace(/\/$/, '');
+	}
+
 	const constantEnv: keyof typeof EnvironmentConstants.dataServerUrl =
 		env.isStaging ? 'staging' : env.isDevnet ? 'dev' : 'mainnet';
-	const dataApiUrl = EnvironmentConstants.dataServerUrl[constantEnv];
-	return dataApiUrl.replace('https://', '');
+	return EnvironmentConstants.dataServerUrl[constantEnv];
 };
 
 const getCandleFetchUrl = ({
@@ -116,10 +140,11 @@ const getCandleFetchUrl = ({
 	resolution,
 	startTs,
 	countToFetch,
+	dataApiUrl,
 }: CandleFetchUrlConfig) => {
-	const baseDataApiUrl = getBaseDataApiUrl(env);
+	const baseDataApiUrl = getBaseDataApiUrl(env, dataApiUrl);
 
-	let fetchUrl = `https://${baseDataApiUrl}/market/${getMarketSymbolForMarketId(
+	let fetchUrl = `${baseDataApiUrl}/market/${getMarketSymbolForMarketId(
 		marketId,
 		env
 	)}/candles/${resolution}?limit=${Math.min(countToFetch, CANDLE_FETCH_LIMIT)}`;
@@ -264,6 +289,7 @@ class CandleFetcher {
 			marketId: this.config.marketId,
 			resolution: this.config.resolution,
 			countToFetch: CANDLE_FETCH_LIMIT, // Ask for max candles to ensure we get enough
+			dataApiUrl: this.config.dataApiUrl,
 		});
 
 		// Get the candles and reverse them (into ascending order)
@@ -397,6 +423,7 @@ class CandleFetcher {
 			resolution: this.config.resolution,
 			startTs: currentStartTs, // Include startTs for historical candles
 			countToFetch: candlesToFetch,
+			dataApiUrl: this.config.dataApiUrl,
 		});
 
 		const fetchedCandles = await this.fetchCandlesFromApi(fetchUrl);
@@ -521,6 +548,12 @@ export class CandleClient {
 		}
 	> = new Map();
 
+	private readonly dataApiUrl?: string;
+
+	constructor(config?: CandleClientConfig) {
+		this.dataApiUrl = config?.dataApiUrl;
+	}
+
 	public subscribe = async (
 		config: CandleSubscriptionConfig,
 		subscriptionKey: string
@@ -572,7 +605,10 @@ export class CandleClient {
 				nowSeconds * 1000
 			).toISOString()})`
 		);
-		const candleFetcher = new CandleFetcher(config);
+		const candleFetcher = new CandleFetcher({
+			...config,
+			dataApiUrl: config.dataApiUrl ?? this.dataApiUrl,
+		});
 		const candles = await candleFetcher.fetchCandles();
 		return candles;
 	};

--- a/common-ts/src/clients/tvFeed.ts
+++ b/common-ts/src/clients/tvFeed.ts
@@ -9,7 +9,7 @@ import { CandleType, JsonCandle, JsonTrade, MarketId } from '../types';
 import { UIEnv } from '../types/UIEnv';
 import { Candle } from '../utils/candles/Candle';
 import { PollingSequenceGuard } from '../utils/pollingSequenceGuard';
-import { CandleClient } from './candleClient';
+import { CandleClient, CandleClientConfig } from './candleClient';
 import { getBaseAssetSymbol } from '../utils/markets/config';
 
 const VELOCITY_V2_START_TS = 1668470400; // 15th November 2022 ... 2022-11-15T00:00:00.000Z
@@ -222,11 +222,12 @@ export class VelocityTvFeed {
 		negativeColor: string,
 		buySellMarkStrokeColor: string,
 		tvAppTradeDataManager?: TvAppTradeDataManager,
-		marketDecimalConfig?: MarketDecimalConfig
+		marketDecimalConfig?: MarketDecimalConfig,
+		candleClientConfig?: CandleClientConfig
 	) {
 		this.env = env;
 		this.candleType = candleType;
-		this.candleClient = new CandleClient();
+		this.candleClient = new CandleClient(candleClientConfig);
 		this.velocityClient = velocityClient;
 		this.perpMarketConfigs = perpMarketConfigs;
 		this.spotMarketConfigs = spotMarketConfigs;

--- a/common-ts/src/drift/base/details/market/funding.ts
+++ b/common-ts/src/drift/base/details/market/funding.ts
@@ -6,7 +6,7 @@ import {
 import { MarkPriceCache } from '../../../Velocity';
 import { MarketId } from '../../../../types';
 import { getFundingRate } from '../../../utils/funding';
-import { API_URLS, API_ENDPOINTS } from '../../../constants/apiUrls';
+import { MAINNET_API_URLS, API_ENDPOINTS } from '../../../constants/apiUrls';
 
 export const getMarketPredictedFunding = (
 	velocityClient: VelocityClient,
@@ -53,7 +53,7 @@ export const getMarketHistoricalFunding = async (
 	marketSymbol: string = 'SOL-PERP'
 ): Promise<Array<{ slot: number; fundingRatePct: number }>> => {
 	// TODO: if we're hitting the data api a lot we should set up a client file for it.. not sure if necessary
-	const url = `${API_URLS.DATA_API}${API_ENDPOINTS.FUNDING_RATES}?marketName=${marketSymbol}`;
+	const url = `${MAINNET_API_URLS.DATA_API}${API_ENDPOINTS.FUNDING_RATES}?marketName=${marketSymbol}`;
 
 	try {
 		const response = await fetch(url);

--- a/common-ts/src/drift/cli.ts
+++ b/common-ts/src/drift/cli.ts
@@ -16,7 +16,7 @@ import {
 import { sign } from 'tweetnacl';
 import { CentralServerVelocity } from './Velocity/clients/CentralServerVelocity';
 import { ENUM_UTILS } from '../utils';
-import { API_URLS } from './constants/apiUrls';
+import { MAINNET_API_URLS } from './constants/apiUrls';
 import * as path from 'path';
 import {
 	NonMarketOrderType,
@@ -633,7 +633,7 @@ async function openPerpMarketOrderCommand(args: CliArgs): Promise<void> {
 	const direction = args.direction as string;
 	const amount = args.amount as string;
 	const assetType = (args.assetType as string) || 'base';
-	const dlobServerHttpUrl = API_URLS.DLOB;
+	const dlobServerHttpUrl = MAINNET_API_URLS.DLOB;
 
 	if (!userAccount || isNaN(marketIndex) || !direction || !amount) {
 		throw new Error(
@@ -678,8 +678,9 @@ async function openPerpMarketOrderSwiftCommand(args: CliArgs): Promise<void> {
 	const direction = args.direction as string;
 	const amount = args.amount as string;
 	const assetType = (args.assetType as string) || 'base';
-	const dlobServerHttpUrl = API_URLS.DLOB;
-	const swiftServerUrl = (args.swiftServerUrl as string) || API_URLS.SWIFT;
+	const dlobServerHttpUrl = MAINNET_API_URLS.DLOB;
+	const swiftServerUrl =
+		(args.swiftServerUrl as string) || MAINNET_API_URLS.SWIFT;
 
 	if (!userAccount || isNaN(marketIndex) || !direction || !amount) {
 		throw new Error(
@@ -871,7 +872,7 @@ async function openPerpNonMarketOrderSwiftCommand(
 	const limitPrice = args.limitPrice as string;
 	const reduceOnly = (args.reduceOnly as string) === 'true';
 	const postOnly = (args.postOnly as string) || 'none';
-	const swiftServerUrl = API_URLS.SWIFT;
+	const swiftServerUrl = MAINNET_API_URLS.SWIFT;
 
 	if (!userAccount || isNaN(marketIndex) || !direction || !orderType) {
 		throw new Error(

--- a/common-ts/src/drift/constants/apiUrls.ts
+++ b/common-ts/src/drift/constants/apiUrls.ts
@@ -4,21 +4,23 @@
  * These constants define the URLs used within the velocity directory for various Velocity services.
  */
 
-export const API_URLS = {
+import { EnvironmentConstants } from '../../EnvironmentConstants';
+
+export const MAINNET_API_URLS = {
 	/**
 	 * Data API - Used for historical data, funding rates, candles, etc.
 	 */
-	DATA_API: 'https://data.api.drift.trade',
+	DATA_API: EnvironmentConstants.dataServerUrl.mainnet,
 
 	/**
 	 * DLOB (Decentralized Limit Order Book) Server - Used for auction parameters, priority fees, etc.
 	 */
-	DLOB: 'https://dlob.drift.trade',
+	DLOB: EnvironmentConstants.dlobServerHttpUrl.mainnet,
 
 	/**
 	 * Swift Server - Used for signed message (gasless) orders
 	 */
-	SWIFT: 'https://swift.drift.trade',
+	SWIFT: EnvironmentConstants.swiftServerUrl.mainnet,
 } as const;
 
 /**

--- a/common-ts/src/utils/priorityFees.ts
+++ b/common-ts/src/utils/priorityFees.ts
@@ -1,6 +1,7 @@
+import { MAINNET_API_URLS } from '../drift/constants/apiUrls';
 import { MarketId } from 'src/types';
 
-const FEE_ENDPOINT = 'https://dlob.drift.trade/batchPriorityFees';
+const FEE_ENDPOINT = `${MAINNET_API_URLS.DLOB}/batchPriorityFees`;
 
 export const getPriorityFeeLevelFromPercentile = (percentile: number) => {
 	if (percentile < 0 || percentile > 100) {
@@ -46,7 +47,8 @@ export const getHeliusPriorityFeeEstimate = async (
 		| 'medium'
 		| 'high'
 		| 'veryHigh'
-		| 'unsafeMax' = 'high'
+		| 'unsafeMax' = 'high',
+	endpoint = FEE_ENDPOINT
 ): Promise<number[]> => {
 	try {
 		if (!marketIds?.length) {
@@ -64,7 +66,7 @@ export const getHeliusPriorityFeeEstimate = async (
 			});
 		const queryParamsString = `${queryParams.join('&')}`;
 
-		const response = await fetch(`${FEE_ENDPOINT}?${queryParamsString}`, {
+		const response = await fetch(`${endpoint}?${queryParamsString}`, {
 			headers: { 'Content-Type': 'application/json' },
 		});
 


### PR DESCRIPTION
## Summary
- Rename `API_URLS` to `MAINNET_API_URLS` in `apiUrls.ts` and source values from `EnvironmentConstants` instead of hardcoded strings; update all references in `cli.ts`, `funding.ts`, and `priorityFees.ts`
- Add `CandleClientConfig` with optional `dataApiUrl` override to `CandleClient`, allowing callers to route candle HTTP fetches through a same-origin proxy (useful for local dev CORS avoidance); also fixes the URL construction that was prepending `https://` twice
- Thread `CandleClientConfig` through `VelocityTvFeed` constructor so the override reaches `CandleClient`
- Make the `endpoint` param in `getHeliusPriorityFeeEstimate` configurable (defaults to `MAINNET_API_URLS.DLOB`)

## Test plan
- [ ] Candle fetching works with no config (defaults unchanged)
- [ ] Candle fetching works with a custom `dataApiUrl` override (e.g. `/api/data-proxy/dev`)
- [ ] CLI commands (`openPerpMarketOrder`, swift variants) resolve the correct DLOB/Swift URLs
- [ ] `getMarketHistoricalFunding` still fetches from the correct mainnet data API URL