### PR TITLE
feat(common-ts): widen vAMM fallback auction end by 0.1% of oracle

### DIFF
--- a/common-ts/src/drift/base/actions/trade/openPerpOrder/dlobServer/index.ts
+++ b/common-ts/src/drift/base/actions/trade/openPerpOrder/dlobServer/index.ts
@@ -516,6 +516,14 @@ export function deriveFromL2Inputs({
 const VAMM_L2_NUM_ORDERS = DEFAULT_L2_DEPTH_FOR_AUCTION_ORDER_PARAMS; // 100
 
 /**
+ * Extra auction-end / oracle-offset buffer (in basis points of the oracle price)
+ * applied ONLY on the network-free vAMM fallback. The vAMM book carries no resting
+ * limit-order liquidity, so its derived worst/entry prices are coarser than the DLOB
+ * server's; this widens the auction end so degraded-liquidity orders still cross.
+ */
+const VAMM_FALLBACK_END_PRICE_BUFFER_BPS = 10; // 0.1%
+
+/**
  * Network-free last-resort tier: derives auction params from the in-memory perp AMM
  * + oracle when the DLOB server is unreachable. Used by FE-4472 fallback.
  */
@@ -569,6 +577,20 @@ export async function deriveAuctionParamsFromVamm({
 		'DLOB server unreachable — deriving auction params from on-chain vAMM'
 	);
 
+	// Add a 0.1%-of-oracle buffer to the auction end / oracle price offset to
+	// compensate for the vAMM book's coarser (no resting-order) liquidity. Added on
+	// top of any caller-supplied buffer; direction is handled downstream (added for
+	// longs, subtracted for shorts) in getMarketAuctionParams.
+	const fallbackEndPriceBuffer = oraclePrice
+		.muln(VAMM_FALLBACK_END_PRICE_BUFFER_BPS)
+		.divn(10_000);
+	const bufferedInputs: OptionalAuctionParamsRequestInputs = {
+		...optionalAuctionParamsInputs,
+		additionalEndPriceBuffer: (
+			optionalAuctionParamsInputs.additionalEndPriceBuffer ?? new BN(0)
+		).add(fallbackEndPriceBuffer),
+	};
+
 	return deriveFromL2Inputs({
 		l2Data,
 		oraclePrice,
@@ -579,7 +601,7 @@ export async function deriveAuctionParamsFromVamm({
 		direction,
 		baseAmount,
 		reduceOnly,
-		optionalAuctionParamsInputs,
+		optionalAuctionParamsInputs: bufferedInputs,
 		dynamicSlippageConfig,
 		source: 'vamm',
 	});

--- a/common-ts/tests/orderParams/fetchAuctionOrderParams.test.ts
+++ b/common-ts/tests/orderParams/fetchAuctionOrderParams.test.ts
@@ -466,8 +466,11 @@ describe('fetchAuctionOrderParams', () => {
 			expect(result.orderParams.auctionStartPrice?.toString()).to.equal(
 				'100000000'
 			);
+			// auction end = slippage-capped end (100005000) + the 0.1%-of-oracle vAMM
+			// fallback buffer (100000) = 100105000. priceImpact best/worst are the raw
+			// L2-walk prices and are NOT buffered.
 			expect(result.orderParams.auctionEndPrice?.toString()).to.equal(
-				'100005000'
+				'100105000'
 			);
 
 			expect(result.meta.priceImpact?.bestPrice.toString()).to.equal(
@@ -499,6 +502,32 @@ describe('fetchAuctionOrderParams', () => {
 			);
 		});
 
+		it('applies a 0.1% oracle-price buffer to the auction end in the vAMM fallback', async () => {
+			// The vAMM book has no resting-order liquidity, so its pricing is coarser
+			// than the DLOB server's. Widen the auction end (and thus the oracle price
+			// offset) by 0.1% of the oracle price so degraded-liquidity orders still cross.
+			const oracle = new BN(100).mul(PRICE_PRECISION); // matches makeVammClientStub
+			const minBuffer = oracle.divn(1000); // 0.1%
+
+			const long = await deriveAuctionParamsFromVamm({
+				...baseParams,
+				velocityClient: makeVammClientStub(),
+				optionalAuctionParamsInputs: { slippageTolerance: 0.005 },
+			});
+			expect(
+				(long.orderParams.auctionEndPrice as BN).sub(oracle).gte(minBuffer)
+			).to.be.true;
+
+			const short = await deriveAuctionParamsFromVamm({
+				...baseParams,
+				direction: PositionDirection.SHORT,
+				velocityClient: makeVammClientStub(),
+				optionalAuctionParamsInputs: { slippageTolerance: 0.005 },
+			});
+			expect(oracle.sub(short.orderParams.auctionEndPrice as BN).gte(minBuffer))
+				.to.be.true;
+		});
+
 		it('derives auction params from the vAMM for a SHORT order, walking the price down', async () => {
 			const result = await deriveAuctionParamsFromVamm({
 				...baseParams,
@@ -514,8 +543,10 @@ describe('fetchAuctionOrderParams', () => {
 			expect(result.orderParams.auctionStartPrice?.toString()).to.equal(
 				'100000000'
 			);
+			// SHORT: slippage-capped end (99995000) minus the 0.1%-of-oracle vAMM
+			// fallback buffer (100000) = 99895000. priceImpact is unbuffered.
 			expect(result.orderParams.auctionEndPrice?.toString()).to.equal(
-				'99995000'
+				'99895000'
 			);
 
 			expect(result.meta.priceImpact?.bestPrice.toString()).to.equal(
@@ -551,8 +582,9 @@ describe('fetchAuctionOrderParams', () => {
 			expect(result.orderParams.auctionStartPrice?.toString()).to.equal(
 				'100000000'
 			);
+			// includes the 0.1%-of-oracle vAMM fallback buffer (+100000 on the long end)
 			expect(result.orderParams.auctionEndPrice?.toString()).to.equal(
-				'100005000'
+				'100105000'
 			);
 
 			expect(result.meta.priceImpact?.bestPrice.gt(new BN(0))).to.be.true;
@@ -587,8 +619,9 @@ describe('fetchAuctionOrderParams', () => {
 			expect(result.orderParams.auctionStartPrice?.toString()).to.equal(
 				'100000000'
 			);
+			// SHORT end = 99999500 minus the 0.1%-of-oracle vAMM fallback buffer (100000)
 			expect(result.orderParams.auctionEndPrice?.toString()).to.equal(
-				'99999500'
+				'99899500'
 			);
 			expect(result.meta.priceImpact?.bestPrice.toString()).to.equal(
 				'99999500'


### PR DESCRIPTION
## Summary
- The vAMM fallback book (FE-4472) has no resting-order liquidity, so its derived worst/entry prices are coarser than the DLOB server's.
- Add a 0.1%-of-oracle buffer to the auction end price (and thus the oracle price offset) on the vAMM tier only, via the existing `additionalEndPriceBuffer` mechanism, so degraded-liquidity orders still cross.
- Applied on top of any caller-supplied buffer; direction handled downstream (added for longs, subtracted for shorts). The `/batchL2` tier (real orderbook liquidity) is unchanged.

## Test plan
- [x] Updated `fetchAuctionOrderParams.test.ts` expectations for the new buffered auction end prices (long/short cases).
- [x] Added a dedicated test asserting the 0.1% oracle-price buffer is applied for both long and short vAMM fallback orders.