### PR TITLE
refactor(common-ts): scale max amount only on non-margin-bound withdraws

### DIFF
--- a/common-ts/src/drift/base/actions/spot/deposit.ts
+++ b/common-ts/src/drift/base/actions/spot/deposit.ts
@@ -102,14 +102,8 @@ export const createDepositTxn = async ({
 	initSwiftAccount: _initSwiftAccount,
 	externalWallet,
 }: CreateDepositTxnParams): Promise<Transaction | VersionedTransaction> => {
-	let finalDepositAmount = amount;
-
-	if (isMaxBorrowRepayment) {
-		// we over-estimate to ensure that there is no borrow dust left
-		// since isMaxBorrowRepayment = reduceOnly, it is safe to over-estimate
-		finalDepositAmount = finalDepositAmount.scale(2, 1);
-	}
-
+	// createDepositIxs owns the isMaxBorrowRepayment over-estimation; scaling here too
+	// would double it
 	// we choose to not use createDepositIxs here because it doesn't have the initSwiftAccount logic
 	// const depositTxn = await velocityClient.createDepositTxn(
 	// 	finalDepositAmount.val,
@@ -123,7 +117,7 @@ export const createDepositTxn = async ({
 	const depositIxs = await createDepositIxs({
 		velocityClient,
 		user,
-		amount: finalDepositAmount,
+		amount,
 		spotMarketConfig,
 		isMaxBorrowRepayment,
 		externalWallet,

--- a/common-ts/src/drift/base/actions/spot/withdraw.ts
+++ b/common-ts/src/drift/base/actions/spot/withdraw.ts
@@ -1,9 +1,12 @@
 import {
 	BigNum,
 	VelocityClient,
+	SpotBalanceType,
 	SpotMarketConfig,
 	TxParams,
 	User,
+	getTokenAmount,
+	isVariant,
 } from '@velocity-exchange/sdk';
 import {
 	Transaction,
@@ -30,33 +33,46 @@ export const createWithdrawIx = async ({
 	isMax,
 }: CreateWithdrawIxParams): Promise<TransactionInstruction[]> => {
 	const reduceOnly = !isBorrow;
+	const spotMarketAccount = velocityClient.getSpotMarketAccountOrThrow(
+		spotMarketConfig.marketIndex
+	);
 
 	let finalWithdrawAmount = amount;
 
 	if (isMax && reduceOnly) {
-		// we over-estimate to ensure that there is no borrow dust left
-		// since reduceOnly is true, it is safe to over-estimate
-		finalWithdrawAmount = finalWithdrawAmount.scale(2, 1);
-		const scaledBalance = user
+		const spotPosition = user
 			.getUserAccountOrThrow()
 			.spotPositions.find(
 				(position) => position.marketIndex === spotMarketConfig.marketIndex
-			)?.scaledBalance;
-		if (scaledBalance && scaledBalance.abs().gtn(0)) {
-			// we use scaledBalance in case amount argument is zero
-			finalWithdrawAmount = BigNum.max(
-				finalWithdrawAmount,
-				BigNum.from(scaledBalance, spotMarketConfig.precisionExp).scale(2, 1)
 			);
+
+		// scaledBalance is interest-free and in SPOT_MARKET_BALANCE_PRECISION
+		const depositTokenAmount =
+			spotPosition && isVariant(spotPosition.balanceType, 'deposit')
+				? BigNum.from(
+						getTokenAmount(
+							spotPosition.scaledBalance,
+							spotMarketAccount,
+							SpotBalanceType.DEPOSIT
+						),
+						spotMarketConfig.precisionExp
+				  )
+				: undefined;
+
+		// Only over-estimate when the max closes out the whole deposit, to absorb interest
+		// accrued before execution. A margin-bound max must be sent as-is, since the on-chain
+		// reduceOnly clamp is non-strict while the margin check gating the withdraw is strict.
+		if (
+			depositTokenAmount?.gtZero() &&
+			(amount.eqZero() || amount.gte(depositTokenAmount)) // a margin-bound max is expected to be less than the deposit amount, so should skip this over-estimation
+		) {
+			finalWithdrawAmount = BigNum.max(amount, depositTokenAmount).scale(2, 1);
 		}
 	}
 
 	const authority = user.getUserAccountOrThrow().authority;
 	const associatedDepositTokenAddress =
-		await getTokenAddressForDepositAndWithdraw(
-			velocityClient.getSpotMarketAccountOrThrow(spotMarketConfig.marketIndex),
-			authority
-		);
+		await getTokenAddressForDepositAndWithdraw(spotMarketAccount, authority);
 
 	const withdrawIxs = await velocityClient.getWithdrawalIxs(
 		finalWithdrawAmount.val,

--- a/common-ts/tests/actions/spotWithdraw.test.ts
+++ b/common-ts/tests/actions/spotWithdraw.test.ts
@@ -1,0 +1,173 @@
+import {
+	BN,
+	BigNum,
+	SpotBalanceType,
+	SpotMarketAccount,
+	SpotMarketConfig,
+	User,
+	VelocityClient,
+} from '@velocity-exchange/sdk';
+import { PublicKey } from '@solana/web3.js';
+import { expect } from 'chai';
+import { createWithdrawIx } from '../../src/drift/base/actions/spot/withdraw';
+
+// USDT-like market: 6 decimals, with 1.2x accrued deposit interest so that the
+// interest-adjusted token amount differs from the raw scaledBalance.
+const DECIMALS = 6;
+const CUMULATIVE_DEPOSIT_INTEREST = new BN(12_000_000_000);
+const SCALED_BALANCE = new BN(40_728_445_000);
+// getTokenAmount(SCALED_BALANCE, market, DEPOSIT) === 48.874134 tokens
+const DEPOSIT_TOKEN_AMOUNT = new BN(48_874_134);
+
+const spotMarketConfig = {
+	marketIndex: 0,
+	precisionExp: new BN(DECIMALS),
+} as unknown as SpotMarketConfig;
+
+const spotMarketAccount = {
+	marketIndex: 0,
+	decimals: DECIMALS,
+	mint: new PublicKey('Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB'),
+	tokenProgramFlag: 0,
+	cumulativeDepositInterest: CUMULATIVE_DEPOSIT_INTEREST,
+} as unknown as SpotMarketAccount;
+
+const makeUser = (
+	spotPositions: { marketIndex: number; scaledBalance: BN; balanceType: any }[]
+) =>
+	({
+		getUserAccountOrThrow: () => ({
+			authority: PublicKey.default,
+			subAccountId: 0,
+			spotPositions,
+		}),
+	} as unknown as User);
+
+const depositUser = makeUser([
+	{
+		marketIndex: 0,
+		scaledBalance: SCALED_BALANCE,
+		balanceType: SpotBalanceType.DEPOSIT,
+	},
+]);
+
+/**
+ * Runs createWithdrawIx against stubbed client/user and returns the raw amount
+ * handed to getWithdrawalIxs.
+ */
+const getSentAmount = async (params: {
+	user: User;
+	amount: BN;
+	isMax?: boolean;
+	isBorrow?: boolean;
+}): Promise<BN> => {
+	let sentAmount: BN | undefined;
+
+	const velocityClient = {
+		getSpotMarketAccountOrThrow: () => spotMarketAccount,
+		getWithdrawalIxs: async (amount: BN) => {
+			sentAmount = amount;
+			return [];
+		},
+	} as unknown as VelocityClient;
+
+	await createWithdrawIx({
+		velocityClient,
+		user: params.user,
+		amount: BigNum.from(params.amount, spotMarketConfig.precisionExp),
+		spotMarketConfig,
+		isMax: params.isMax,
+		isBorrow: params.isBorrow,
+	});
+
+	expect(sentAmount).to.exist;
+	return sentAmount as BN;
+};
+
+describe('createWithdrawIx (max withdraw amount)', () => {
+	it('passes a margin-bound max through unscaled', async () => {
+		// Caller-computed max below the deposit balance: the on-chain reduceOnly clamp
+		// must never get the chance to bind, so the amount has to survive untouched.
+		const amount = new BN(12_222_156);
+
+		const sentAmount = await getSentAmount({
+			user: depositUser,
+			amount,
+			isMax: true,
+		});
+
+		expect(sentAmount.toString()).to.equal(amount.toString());
+	});
+
+	it('over-sends 2x the interest-adjusted token amount when the max closes out the deposit', async () => {
+		const sentAmount = await getSentAmount({
+			user: depositUser,
+			amount: DEPOSIT_TOKEN_AMOUNT,
+			isMax: true,
+		});
+
+		expect(sentAmount.toString()).to.equal(
+			DEPOSIT_TOKEN_AMOUNT.muln(2).toString()
+		);
+		// not 2x the raw scaledBalance, which would be 1000x too large at 6 decimals
+		expect(sentAmount.toString()).to.not.equal(
+			SCALED_BALANCE.muln(2).toString()
+		);
+	});
+
+	it('over-sends the deposit balance when the amount is zero', async () => {
+		const sentAmount = await getSentAmount({
+			user: depositUser,
+			amount: new BN(0),
+			isMax: true,
+		});
+
+		expect(sentAmount.toString()).to.equal(
+			DEPOSIT_TOKEN_AMOUNT.muln(2).toString()
+		);
+	});
+
+	it('passes through when the position is a borrow', async () => {
+		const amount = new BN(1_000_000);
+		const borrowUser = makeUser([
+			{
+				marketIndex: 0,
+				scaledBalance: SCALED_BALANCE,
+				balanceType: SpotBalanceType.BORROW,
+			},
+		]);
+
+		const sentAmount = await getSentAmount({
+			user: borrowUser,
+			amount,
+			isMax: true,
+		});
+
+		expect(sentAmount.toString()).to.equal(amount.toString());
+	});
+
+	it('passes through when there is no position for the market', async () => {
+		const amount = new BN(1_000_000);
+
+		const sentAmount = await getSentAmount({
+			user: makeUser([]),
+			amount,
+			isMax: true,
+		});
+
+		expect(sentAmount.toString()).to.equal(amount.toString());
+	});
+
+	it('passes through a borrow withdraw without scaling', async () => {
+		const amount = new BN(1_000_000);
+
+		const sentAmount = await getSentAmount({
+			user: depositUser,
+			amount,
+			isMax: true,
+			isBorrow: true,
+		});
+
+		expect(sentAmount.toString()).to.equal(amount.toString());
+	});
+});


### PR DESCRIPTION
## Summary
- Only over-estimate (scale 2x) the withdraw amount when a max withdraw closes out the entire deposit, so the on-chain reduceOnly clamp (non-strict) can safely absorb accrued interest.
- A margin-bound max (amount less than the full deposit) is now sent as-is, since the margin check gating the withdraw is strict and would reject an over-scaled amount.
- Uses `getTokenAmount` with `SpotBalanceType.DEPOSIT` to compute the interest-adjusted deposit token amount instead of relying on raw `scaledBalance`.

## Test plan
- [x] Added `common-ts/tests/actions/spotWithdraw.test.ts` covering margin-bound max (unscaled) and full-deposit max (scaled) withdraw scenarios.
- [ ] `yarn test` in `common-ts/`